### PR TITLE
Fix broken setup command shown in Add-a-machine GUI

### DIFF
--- a/client/src/components/WorkerCard.tsx
+++ b/client/src/components/WorkerCard.tsx
@@ -13,43 +13,56 @@ export const SETUP_OS_LABELS: Array<{ key: SetupOS; label: string; badgeClass: s
   { key: "linux", label: "LINUX", badgeClass: "text-[#f0b86e] bg-[#f0b86e]/15" },
 ];
 
+export interface SetupScenario {
+  title: string;
+  desc: string;
+  cmd: Record<SetupOS, string>;
+}
+
+// vpsUrl is this server's own public origin (pass window.location.origin --
+// the page showing this command IS served from PUBLIC_URL, see
+// deploy/orchestrator.env.example) -- baked into the fresh-install command
+// so it's copy-paste-runnable as-is instead of erroring with "-VpsUrl is
+// required" (bootstrap.ps1/bootstrap.sh both require it on first setup).
+// Already-cloned/restart need no URL: by then config.json has it saved.
+//
 // Exported for client/src/pages/Device.tsx's own install-command display
 // (MULTIUSER_PLAN.md §3.1) -- single source of truth so an existing worker's
 // restart/reinstall reference panel here and the "Add machine" onboarding
 // screen there never drift apart. Kept in sync with worker/bootstrap.ps1,
 // worker/bootstrap.sh, worker/setup-worker.ps1, worker/setup-worker.sh, and
 // README.md's "Running the worker (GPU box)" section.
-export const FRESH_INSTALL_CMD: Record<SetupOS, string> = {
-  windows: 'iex "& { $(irm https://raw.githubusercontent.com/noname9006/LlamaToaster/main/worker/bootstrap.ps1) }"',
-  macos: "curl -fsSL https://raw.githubusercontent.com/noname9006/LlamaToaster/main/worker/bootstrap.sh | bash",
-  linux: "curl -fsSL https://raw.githubusercontent.com/noname9006/LlamaToaster/main/worker/bootstrap.sh | bash",
-};
-
-const SETUP_SCENARIOS: Array<{ title: string; desc: string; cmd: Record<SetupOS, string> }> = [
-  {
-    title: "Fresh install",
-    desc: "Brand-new machine, nothing downloaded yet (no repo, no config, no llama.cpp) -- one command fetches the repo, installs dependencies, and starts the worker. It'll ask which drive/volume to use (showing free space -- models are often tens of GB each) and a folder name, then create it.",
-    cmd: FRESH_INSTALL_CMD,
-  },
-  {
-    title: "Already cloned",
-    desc: "Already have the repo checked out -- same command for first setup (still asks where, unless you pass a folder) and every restart after. Run from the repo root.",
-    cmd: {
-      windows: ".\\worker\\setup-worker.ps1",
-      macos: "bash worker/setup-worker.sh",
-      linux: "bash worker/setup-worker.sh",
+export function buildSetupScenarios(vpsUrl: string): SetupScenario[] {
+  return [
+    {
+      title: "Fresh install",
+      desc: "Brand-new machine, nothing downloaded yet (no repo, no config, no llama.cpp) -- one command fetches the repo, installs dependencies, and starts the worker. It'll ask which drive/volume to use (showing free space -- models are often tens of GB each) and a folder name, then create it.",
+      cmd: {
+        windows: `iex "& { $(irm https://raw.githubusercontent.com/noname9006/LlamaToaster/main/worker/bootstrap.ps1) } -VpsUrl ${vpsUrl}"`,
+        macos: `curl -fsSL https://raw.githubusercontent.com/noname9006/LlamaToaster/main/worker/bootstrap.sh | bash -s -- --vps-url ${vpsUrl}`,
+        linux: `curl -fsSL https://raw.githubusercontent.com/noname9006/LlamaToaster/main/worker/bootstrap.sh | bash -s -- --vps-url ${vpsUrl}`,
+      },
     },
-  },
-  {
-    title: "Restart",
-    desc: "Once it's already set up, a plain restart.",
-    cmd: {
-      windows: "worker\\start.bat",
-      macos: "npm run worker",
-      linux: "npm run worker",
+    {
+      title: "Already installed",
+      desc: "Already have the repo checked out -- same command for first setup (still asks where, unless you pass a folder) and every restart after. Run from the repo root.",
+      cmd: {
+        windows: ".\\worker\\setup-worker.ps1",
+        macos: "bash worker/setup-worker.sh",
+        linux: "bash worker/setup-worker.sh",
+      },
     },
-  },
-];
+    {
+      title: "Restart",
+      desc: "Once it's already set up and running, stop it (Ctrl+C, or close the window) and run this to start it again -- reuses the saved config.json as-is, no prompts.",
+      cmd: {
+        windows: "worker\\start.bat",
+        macos: "npm run worker",
+        linux: "npm run worker",
+      },
+    },
+  ];
+}
 
 export function CopyCommandButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
@@ -165,7 +178,7 @@ export function WorkerCard({ worker, onRefresh }: { worker: Worker; onRefresh: (
           <IconChevronDown width={14} height={14} className="transition-transform group-open:rotate-180" />
         </summary>
         <div className="flex flex-col gap-3 border-t border-border p-3">
-          {SETUP_SCENARIOS.map((scenario, i) => (
+          {buildSetupScenarios(window.location.origin).map((scenario, i) => (
             <div key={scenario.title} className="overflow-hidden rounded-lg border border-border">
               <div className="bg-surface-raised px-3 py-2.5">
                 <div className="flex items-center gap-2">

--- a/client/src/pages/Device.tsx
+++ b/client/src/pages/Device.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { api } from "../api/client";
 import type { DeviceStatusResponse } from "../types";
-import { CopyCommandButton, SETUP_OS_LABELS, FRESH_INSTALL_CMD, type SetupOS } from "../components/WorkerCard";
+import { CopyCommandButton, SETUP_OS_LABELS, buildSetupScenarios, type SetupOS } from "../components/WorkerCard";
 import { IconServer, IconInfo, IconCheck } from "../components/icons";
 
 // Matches server/src/session.ts's generateUserCode (4 chars, a dash, 4 more,
@@ -40,6 +40,11 @@ export function Device() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [approvedHost, setApprovedHost] = useState<string | null>(null);
+
+  // This page's own origin IS the server's public URL (see
+  // WorkerCard.tsx's buildSetupScenarios doc comment) -- stable for the
+  // life of the page, so computed once rather than on every render.
+  const setupScenarios = useMemo(() => buildSetupScenarios(window.location.origin), []);
 
   useEffect(() => {
     api
@@ -129,8 +134,9 @@ export function Device() {
     <div className="max-w-2xl">
       <h1 className="text-2xl font-semibold text-fg">Add a machine</h1>
       <p className="mt-2 text-sm text-muted">
-        Run this on the GPU box you want to connect — it's the same command every time, for every
-        machine. It prints a one-time code; enter that code below once it appears.
+        Run whichever of these matches the GPU box you want to connect. Setting it up for the
+        first time (or reconnecting a machine whose session was revoked) prints a one-time code —
+        enter that code below once it appears. A plain restart doesn't need this page at all.
       </p>
 
       <div className="mt-6 flex gap-1.5">
@@ -147,11 +153,30 @@ export function Device() {
           </button>
         ))}
       </div>
-      <div className="mt-2 flex items-start gap-3 rounded-lg border border-border bg-surface-raised px-3 py-2.5">
-        <code className="flex-1 whitespace-pre-wrap break-all font-mono text-xs text-fg">
-          {FRESH_INSTALL_CMD[os]}
-        </code>
-        <CopyCommandButton text={FRESH_INSTALL_CMD[os]} />
+      {/* First-run command has this page's own origin baked in as -VpsUrl/
+          --vps-url (see WorkerCard.tsx's buildSetupScenarios) -- copy-paste
+          runs as-is instead of erroring "-VpsUrl is required". Already-
+          installed/restart need no URL: config.json has it saved by then. */}
+      <div className="mt-2 flex flex-col gap-3">
+        {setupScenarios.map((scenario, i) => (
+          <div key={scenario.title} className="overflow-hidden rounded-lg border border-border">
+            <div className="bg-surface-raised px-3 py-2">
+              <div className="flex items-center gap-2">
+                <span className="flex h-5 w-5 flex-none items-center justify-center rounded-md bg-accent/15 font-mono text-[11px] font-bold text-accent">
+                  {i + 1}
+                </span>
+                <span className="text-sm font-semibold text-fg">{scenario.title}</span>
+              </div>
+              <p className="mt-1 text-xs leading-relaxed text-muted">{scenario.desc}</p>
+            </div>
+            <div className="flex items-start gap-3 border-t border-border bg-bg px-3 py-2.5">
+              <code className="flex-1 whitespace-pre-wrap break-all font-mono text-xs text-fg">
+                {scenario.cmd[os]}
+              </code>
+              <CopyCommandButton text={scenario.cmd[os]} />
+            </div>
+          </div>
+        ))}
       </div>
 
       {approvedHost ? (


### PR DESCRIPTION
## Summary

One trailing commit that landed on `MULTIUSER` after #2 merged.

- The fresh-install command shown in the GUI was missing `-VpsUrl`/`--vps-url` entirely, reproducing the exact "-VpsUrl is required" error a user hit copy-pasting it.
- `buildSetupScenarios` now bakes in the page's own origin so the command is copy-paste-runnable as-is.
- The "Add a machine" page now shows all three setup scenarios (fresh install / already installed / restart) instead of just the first.

## Test plan

- [x] `npm run build` — clean
- [x] Live-verified in browser: all three OS variants render the correct command, `-VpsUrl` present and correctly placed inside the quoted string

🤖 Generated with [Claude Code](https://claude.com/claude-code)