### PR TITLE
Platform-wide Dashboard stats, enrolment code box, HF pagination fix

### DIFF
--- a/client/src/api/client.ts
+++ b/client/src/api/client.ts
@@ -26,6 +26,7 @@ import {
   type ImportResponse,
   type VerifiedLimitDto,
   type ProbeAttemptDto,
+  type AdminStats,
 } from "../types";
 
 export class ApiError extends Error {
@@ -408,9 +409,9 @@ export const api = {
   getModelHfUpdates: (): Promise<Record<string, string | null>> =>
     request<{ updates: Record<string, string | null> }>("/api/models/hf-updates").then((d) => d.updates),
 
-  // The one intentionally cross-tenant number on the (otherwise
-  // per-account-scoped) Dashboard -- see Dashboard.tsx's own header comment.
-  getStats: (): Promise<{ users: number }> => request("/api/stats"),
+  // The platform-wide stat-card numbers on the Dashboard -- see
+  // Dashboard.tsx's own header comment.
+  getStats: (): Promise<AdminStats> => request("/api/stats"),
 
   // Hash lookup: sends SHA-256 hashes of local files and gets back the
   // matching HF metadata (repo_id, filename, revision) so the Models page

--- a/client/src/api/useDeviceEnrolment.ts
+++ b/client/src/api/useDeviceEnrolment.ts
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { api } from "./client";
+import type { DeviceStatusResponse } from "../types";
+
+// Matches server/src/session.ts's generateUserCode (4 chars, a dash, 4 more,
+// drawn from Crockford base32 minus ambiguous characters) -- used both to
+// know when the field is "full enough to poll" and to reject obviously
+// unfinished input before it ever reaches the server.
+const CODE_RE = /^[A-Z0-9]{4}-[A-Z0-9]{4}$/;
+
+function normalizeCodeInput(raw: string): string {
+  const upper = raw
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "")
+    .slice(0, 8);
+  return upper.length > 4 ? `${upper.slice(0, 4)}-${upper.slice(4)}` : upper;
+}
+
+const POLL_INTERVAL_MS = 2000;
+
+// Enrolment code entry + polling + approve/deny, extracted out of
+// AddMachinePanel so a caller (Workers.tsx) can render a compact code box
+// elsewhere on the page -- e.g. next to the collapsed "Add a machine"
+// summary -- while it stays wired to the very same state as the full panel
+// underneath it.
+export function useDeviceEnrolment() {
+  const [codeInput, setCodeInput] = useState("");
+  const [status, setStatus] = useState<DeviceStatusResponse | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [approved, setApproved] = useState<{ hostname: string; merged: boolean } | null>(null);
+
+  const validCode = CODE_RE.test(codeInput);
+
+  // Polls GET /api/device/status while a full-length code is present (§3.1
+  // step 4) -- stops as soon as it resolves to "approved" (whether from this
+  // tab's own Approve click below, or a second browser tab/device that
+  // approved it first) or the input changes to something no longer a full
+  // code.
+  useEffect(() => {
+    if (!validCode) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    async function poll() {
+      try {
+        const s = await api.getDeviceStatus(codeInput);
+        if (cancelled) return;
+        setStatus(s);
+        setError(null);
+        if (s.state === "approved" && timer) {
+          clearInterval(timer);
+          timer = null;
+        }
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+    void poll();
+    timer = setInterval(poll, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [validCode, codeInput]);
+
+  function handleCodeChange(raw: string) {
+    setCodeInput(normalizeCodeInput(raw));
+    setStatus(null);
+    setError(null);
+  }
+
+  async function handleApprove(mergeInto?: string) {
+    setBusy(true);
+    setError(null);
+    try {
+      // confirm_duplicate reflects what the last status poll already showed
+      // -- see server/src/routes/device.ts's POST /api/device/approve and
+      // workerRepo.findPossibleDuplicate's doc comment for why this exists:
+      // deleting a worker's install folder wipes its persisted machine_id,
+      // so re-running setup looks like a brand-new machine to the server,
+      // and without this check would silently create an indistinguishable
+      // duplicate of a machine the user already has. mergeInto instead asks
+      // the server to re-attach this connection to that existing machine.
+      const confirmDuplicate = !mergeInto && status?.state === "pending" && status.possibleDuplicate != null;
+      const res = await api.approveDevice(codeInput, confirmDuplicate, mergeInto);
+      if (!res.ok) {
+        // Race: the duplicate was only detected server-side just now (this
+        // poll hadn't caught up yet) -- the next poll tick will pick up
+        // possibleDuplicate and relabel the buttons; nothing was approved.
+        setError('This machine looks like one you already have -- pick "Merge" or "Add as new machine" once it appears below.');
+        return;
+      }
+      setApproved({ hostname: res.machine.hostname ?? "This machine", merged: res.merged === true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // No dedicated deny endpoint exists (or needs to) -- a code nobody approves
+  // just expires on its own in 15 minutes (server/src/routes/device.ts's
+  // ENROLMENT_TTL_MS). This just walks the user away from the confirm card.
+  function handleDeny() {
+    setCodeInput("");
+    setStatus(null);
+    setError(null);
+  }
+
+  return {
+    codeInput,
+    handleCodeChange,
+    validCode,
+    status,
+    busy,
+    error,
+    approved,
+    handleApprove,
+    handleDeny,
+  };
+}

--- a/client/src/components/AddMachinePanel.tsx
+++ b/client/src/components/AddMachinePanel.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { api } from "../api/client";
-import type { DeviceStatusResponse } from "../types";
+import { useMemo, useState } from "react";
+import { useDeviceEnrolment } from "../api/useDeviceEnrolment";
 import {
   CopyCommandButton,
   PowerShellNotice,
@@ -12,121 +11,35 @@ import {
 import { IconServer, IconInfo, IconCheck } from "./icons";
 import { formatRelativeTime } from "../utils";
 
-// Matches server/src/session.ts's generateUserCode (4 chars, a dash, 4 more,
-// drawn from Crockford base32 minus ambiguous characters) -- used both to
-// know when the field is "full enough to poll" and to reject obviously
-// unfinished input before it ever reaches the server.
-const CODE_RE = /^[A-Z0-9]{4}-[A-Z0-9]{4}$/;
-
-function normalizeCodeInput(raw: string): string {
-  const upper = raw
-    .toUpperCase()
-    .replace(/[^A-Z0-9]/g, "")
-    .slice(0, 8);
-  return upper.length > 4 ? `${upper.slice(0, 4)}-${upper.slice(4)}` : upper;
-}
-
-const POLL_INTERVAL_MS = 2000;
-
 // MULTIUSER_PLAN.md §3.1's "Add machine" screen, extracted from pages/
 // Device.tsx so it can be embedded directly on the Workers page (top of the
 // page) AND still rendered by the bookmarkable /device route -- it's the
 // SAME component either way, not two separate screens. Assumes a logged-in
 // session with AUTH_ENABLED (the /device route checks that itself before
 // rendering this).
-export function AddMachinePanel() {
+//
+// Enrolment-code state (Workers.tsx also shows a compact code box next to
+// the collapsed "Add a machine" summary, wired to this same state) can be
+// passed in via `enrolment`; when omitted (the /device route's standalone
+// use) this component creates its own.
+export function AddMachinePanel({
+  enrolment,
+}: {
+  enrolment?: ReturnType<typeof useDeviceEnrolment>;
+}) {
   // Pre-selected from the browser's own OS (§1 of the Settings/Device
   // rework) so the right setup command is already showing on first paint --
   // still just the tab's initial value, so a click on WIN/MACOS/LINUX above
   // freely overrides it same as before.
   const [os, setOs] = useState<SetupOS>(() => detectOS());
-  const [codeInput, setCodeInput] = useState("");
-  const [status, setStatus] = useState<DeviceStatusResponse | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [approved, setApproved] = useState<{ hostname: string; merged: boolean } | null>(null);
+  const ownEnrolment = useDeviceEnrolment();
+  const { codeInput, handleCodeChange, validCode, status, busy, error, approved, handleApprove, handleDeny } =
+    enrolment ?? ownEnrolment;
 
   // This page's origin IS the server's public URL (see
   // WorkerCard.tsx's buildSetupScenarios doc comment) -- stable for the
   // life of the page, so computed once rather than on every render.
   const setupScenarios = useMemo(() => buildSetupScenarios(window.location.origin), []);
-
-  const validCode = CODE_RE.test(codeInput);
-
-  // Polls GET /api/device/status while a full-length code is present (§3.1
-  // step 4) -- stops as soon as it resolves to "approved" (whether from this
-  // tab's own Approve click below, or a second browser tab/device that
-  // approved it first) or the input changes to something no longer a full
-  // code.
-  useEffect(() => {
-    if (!validCode) return;
-    let cancelled = false;
-    let timer: ReturnType<typeof setInterval> | null = null;
-    async function poll() {
-      try {
-        const s = await api.getDeviceStatus(codeInput);
-        if (cancelled) return;
-        setStatus(s);
-        setError(null);
-        if (s.state === "approved" && timer) {
-          clearInterval(timer);
-          timer = null;
-        }
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : String(err));
-      }
-    }
-    void poll();
-    timer = setInterval(poll, POLL_INTERVAL_MS);
-    return () => {
-      cancelled = true;
-      if (timer) clearInterval(timer);
-    };
-  }, [validCode, codeInput]);
-
-  function handleCodeChange(raw: string) {
-    setCodeInput(normalizeCodeInput(raw));
-    setStatus(null);
-    setError(null);
-  }
-
-  async function handleApprove(mergeInto?: string) {
-    setBusy(true);
-    setError(null);
-    try {
-      // confirm_duplicate reflects what the last status poll already showed
-      // -- see server/src/routes/device.ts's POST /api/device/approve and
-      // workerRepo.findPossibleDuplicate's doc comment for why this exists:
-      // deleting a worker's install folder wipes its persisted machine_id,
-      // so re-running setup looks like a brand-new machine to the server,
-      // and without this check would silently create an indistinguishable
-      // duplicate of a machine the user already has. mergeInto instead asks
-      // the server to re-attach this connection to that existing machine.
-      const confirmDuplicate = !mergeInto && status?.state === "pending" && status.possibleDuplicate != null;
-      const res = await api.approveDevice(codeInput, confirmDuplicate, mergeInto);
-      if (!res.ok) {
-        // Race: the duplicate was only detected server-side just now (this
-        // poll hadn't caught up yet) -- the next poll tick will pick up
-        // possibleDuplicate and relabel the buttons; nothing was approved.
-        setError('This machine looks like one you already have -- pick "Merge" or "Add as new machine" once it appears below.');
-        return;
-      }
-      setApproved({ hostname: res.machine.hostname ?? "This machine", merged: res.merged === true });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  // No dedicated deny endpoint exists (or needs to) -- a code nobody approves
-  // just expires on its own in 15 minutes (server/src/routes/device.ts's
-  // ENROLMENT_TTL_MS). This just walks the user away from the confirm card.
-  function handleDeny() {
-    setCodeInput("");
-    setStatus(null);
-    setError(null);
-  }
 
   return (
     <div className="max-w-2xl">
@@ -191,20 +104,28 @@ export function AddMachinePanel() {
         </div>
       ) : (
         <div className="mt-6">
-          <label htmlFor="device-code" className="text-sm font-semibold text-fg">
-            Have a code?
-          </label>
-          <div>
-            <input
-              id="device-code"
-              type="text"
-              value={codeInput}
-              onChange={(e) => handleCodeChange(e.target.value)}
-              placeholder="ABCD-EFGH"
-              maxLength={9}
-              className="mt-1.5 w-40 rounded-lg border border-border bg-surface px-3 py-2 text-center font-mono text-sm uppercase tracking-widest text-fg outline-none focus:border-accent/50"
-            />
-          </div>
+          {/* When embedded on the Workers page (`enrolment` passed in), the
+              same code box already sits next to the "Add a machine" summary
+              above -- showing it again here would just be a second box bound
+              to the same state. Standalone (/device route) still needs it. */}
+          {!enrolment && (
+            <>
+              <label htmlFor="device-code" className="text-sm font-semibold text-fg">
+                Have a code?
+              </label>
+              <div>
+                <input
+                  id="device-code"
+                  type="text"
+                  value={codeInput}
+                  onChange={(e) => handleCodeChange(e.target.value)}
+                  placeholder="ABCD-EFGH"
+                  maxLength={9}
+                  className="mt-1.5 w-40 rounded-lg border border-border bg-surface px-3 py-2 text-center font-mono text-sm uppercase tracking-widest text-fg outline-none focus:border-accent/50"
+                />
+              </div>
+            </>
+          )}
 
           {error && <p className="mt-2 text-sm text-danger">{error}</p>}
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,48 +1,147 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { api } from "../api/client";
 import { StatCard } from "../components/StatCard";
 import { TestStatusPill, StatusPill, type PillTone } from "../components/StatusPill";
 import { TokSpeedDemo } from "../components/TokSpeedDemo";
-import type { Test, Worker } from "../types";
-import { shortId, formatGpuLabel } from "../utils";
+import { SETUP_OS_LABELS, platformToSetupOS } from "../components/WorkerCard";
+import { IconX } from "../components/icons";
+import type { AdminStats, Test, Worker } from "../types";
+import { shortId, formatGpuLabel, formatBytes } from "../utils";
 
-// Multi-user Stage 5 (MULTIUSER_PLAN.md §5.2): "machines, not users" for
-// every number EXCEPT the "Users" stat card below -- every other number and
-// machine shown here comes from api.listWorkers()/api.listTests(), both
-// already scoped to the caller's own account once authenticated (Stage 4's
-// own §4.3/§4.5 scoping) and unfiltered in single-tenant mode (AUTH_ENABLED
-// off), unchanged from before that scoping existed. "Users" is a deliberate,
-// later exception (operator request): a single unscoped GET /api/stats call
-// (server/src/routes/stats.ts) returning just a total account count, no
-// per-user data -- every signed-in user sees the same platform-wide number,
-// not just a superadmin. A superadmin otherwise sees exactly this same
-// personal dashboard, no branch, no admin link -- the full cross-tenant view
-// (every user's own machines/runs) still lives entirely on the separate
-// admin origin (§5.1).
+// Multi-user Stage 5 (MULTIUSER_PLAN.md §5.2) originally made this page
+// "machines, not users": every stat card except "Users" derived from the
+// caller's own api.listWorkers()/api.listTests() (Stage 4's §4.3/§4.5
+// scoping), with only a total account count shown platform-wide. Later
+// operator request reversed that for the stat-card row specifically: all six
+// cards now come from one GET /api/stats call (server/src/routes/stats.ts),
+// which is the same unscoped repo.adminRepo.stats() query the admin surface
+// uses -- aggregate counts only, no per-user breakdown, so it carries the
+// same "just a count" reasoning that already justified exposing the users
+// total here. Every signed-in user sees the same platform-wide numbers, not
+// just a superadmin. The machine list and "Recent tests" section BELOW the
+// stat cards are still the caller's own, via listWorkers()/listTests() --
+// only the headline totals went platform-wide. The full cross-tenant *table*
+// view (every user's own machines/runs, filterable) still lives entirely on
+// the separate admin origin (§5.1).
 const WORKER_STATUS_TONE: Record<Worker["status"], PillTone> = {
   offline: "danger",
   idle: "muted",
   busy: "accent",
 };
 
-function MachineRow({ worker }: { worker: Worker }) {
+const HIDDEN_WORKERS_STORAGE_KEY = "llamatoaster:dashboard:hidden-workers";
+
+function readHiddenWorkers(): string[] {
+  try {
+    const raw = localStorage.getItem(HIDDEN_WORKERS_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeHiddenWorkers(ids: string[]): void {
+  try {
+    localStorage.setItem(HIDDEN_WORKERS_STORAGE_KEY, JSON.stringify(ids));
+  } catch {
+    /* localStorage unavailable (private browsing, quota) -- hiding just won't survive a reload */
+  }
+}
+
+// worker_id is the real FK (MULTIUSER_PLAN.md §1.2); worker_name is only a
+// point-in-time snapshot taken when the test ran, so a run predating that
+// column (or a since-renamed worker) falls back to matching the name that
+// was true back then.
+function testMatchesWorker(r: Test, worker: Worker): boolean {
+  return r.worker_id ? r.worker_id === worker.id : r.worker_name === worker.displayName;
+}
+
+function MachineCard({
+  worker,
+  modelsTested,
+  testsPerformed,
+  selected,
+  hidden,
+  onSelect,
+  onHide,
+  onUnhide,
+}: {
+  worker: Worker;
+  modelsTested: number;
+  testsPerformed: number;
+  selected: boolean;
+  hidden: boolean;
+  onSelect: () => void;
+  onHide: () => void;
+  onUnhide: () => void;
+}) {
   const gpu = worker.hardware?.gpu[0];
+  const osLabel = SETUP_OS_LABELS.find((o) => o.key === platformToSetupOS(worker.platform))?.label ?? worker.platform ?? "unknown OS";
+  const hardwareBits = [
+    worker.hardware?.cpu.brand || worker.hardware?.cpu.manufacturer,
+    worker.hardware?.mem_total_bytes ? formatBytes(worker.hardware.mem_total_bytes) : null,
+    gpu ? formatGpuLabel(gpu) : worker.hardware ? "no GPU" : null,
+  ].filter(Boolean);
+
   return (
-    <div className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3">
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-medium text-fg">{worker.displayName}</span>
-          <StatusPill label={worker.status} tone={WORKER_STATUS_TONE[worker.status]} />
-        </div>
-        <div className="mt-0.5 truncate text-xs text-muted">
-          {[worker.backend, gpu ? formatGpuLabel(gpu) : null].filter(Boolean).join(" · ") || "no details reported yet"}
-        </div>
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+      className={`flex cursor-pointer flex-col gap-2 rounded-lg border px-4 py-3 text-left transition-colors ${
+        selected ? "border-accent/50 bg-accent/10" : "border-border bg-surface hover:border-accent/30"
+      } ${hidden ? "border-dashed opacity-60" : ""}`}
+    >
+      <div className="flex items-center gap-2">
+        <span className="truncate text-sm font-medium text-fg">{worker.displayName}</span>
+        <StatusPill label={worker.status} tone={WORKER_STATUS_TONE[worker.status]} />
+        <span className="ml-auto flex-none">
+          {hidden ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onUnhide();
+              }}
+              className="text-xs font-semibold text-muted hover:text-accent"
+            >
+              Unhide
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onHide();
+              }}
+              className="text-xs font-semibold text-muted hover:text-danger"
+            >
+              Hide
+            </button>
+          )}
+        </span>
+      </div>
+      <div className="truncate text-xs text-muted">
+        {osLabel}
+        {hardwareBits.length ? ` · ${hardwareBits.join(" · ")}` : ""}
+      </div>
+      <div className="mt-1 flex items-center gap-4 text-xs">
+        <span className="text-fg">
+          {modelsTested} <span className="text-muted">models tested</span>
+        </span>
+        <span className="text-fg">
+          {testsPerformed} <span className="text-muted">tests performed</span>
+        </span>
       </div>
       {worker.status === "busy" && worker.activeJobProgress && (
-        <span className="flex-none text-xs text-muted">
-          {worker.activeJobProgress.detail ?? worker.activeJobProgress.phase}
-        </span>
+        <span className="text-xs text-muted">{worker.activeJobProgress.detail ?? worker.activeJobProgress.phase}</span>
       )}
     </div>
   );
@@ -51,8 +150,13 @@ function MachineRow({ worker }: { worker: Worker }) {
 export function Dashboard() {
   const [runs, setRuns] = useState<Test[]>([]);
   const [workers, setWorkers] = useState<Worker[]>([]);
-  const [userCount, setUserCount] = useState<number | null>(null);
+  const [stats, setStats] = useState<AdminStats | null>(null);
   const [loaded, setLoaded] = useState(false);
+  const [selectedWorkerId, setSelectedWorkerId] = useState<string | null>(null);
+  const [hiddenWorkerIds, setHiddenWorkerIds] = useState<string[]>(() => readHiddenWorkers());
+  const [showHidden, setShowHidden] = useState(false);
+  const [hideFailed, setHideFailed] = useState(false);
+  const [hideCancelled, setHideCancelled] = useState(false);
   const timerRef = useRef<number | undefined>(undefined);
 
   // Self-rescheduling poll (same shape as Workers page's useWorkerStatuses)
@@ -67,7 +171,7 @@ export function Dashboard() {
         if (cancelled) return;
         setRuns(r);
         setWorkers(w);
-        setUserCount(s.users);
+        setStats(s);
         setLoaded(true);
       } finally {
         if (!cancelled) timerRef.current = window.setTimeout(poll, 5000);
@@ -80,63 +184,165 @@ export function Dashboard() {
     };
   }, []);
 
-  // A lifetime count, not a live online/total ratio -- see this file's own
-  // header comment and MULTIUSER_PLAN.md §5.2: an online/total ratio makes
-  // the tile flicker as boxes sleep and turns a headline number into a
-  // status widget; per-machine liveness belongs in the strip below, where
-  // it's actionable. Abandoned enrolments (never heartbeated) don't count; a
-  // machine that's merely powered off right now still does.
-  const machinesEverConnected = workers.filter((w) => w.lastHeartbeatAt !== null).length;
-  // Terminal outcomes only (done/failed/failed_oom/cancelled) -- a still-
-  // queued or in-flight item hasn't been performed yet, so items_total alone
-  // (which counts those too) overcounts. Matches the admin dashboard's own
-  // "Tests performed" definition (server/src/db/repo.ts's adminRepo.stats).
-  const testsTotal = runs.reduce((sum, r) => sum + (r.items_done ?? 0) + (r.items_failed ?? 0) + (r.items_cancelled ?? 0), 0);
-  // "Runs" in this app's own vocabulary means repeats (-r), not sweep
-  // combinations or job rows -- see TestDetail.tsx's own totalRuns (items x
-  // repeats) for the per-run version of this same math. A raw runs.length
-  // (job-row count) would undercount relative to testsTotal above, since
-  // one job's several sweep combinations each get counted as one test but
-  // physically execute `repeats` times.
-  const totalRuns = runs.reduce((sum, r) => sum + (r.items_total ?? 0) * (r.config?.sweep?.repeats ?? 1), 0);
-  const distinctModelsTested = new Set(runs.map((r) => r.model_id)).size;
-  const recent = runs.slice(0, 8);
+  function hideWorker(id: string): void {
+    setHiddenWorkerIds((prev) => {
+      if (prev.includes(id)) return prev;
+      const next = [...prev, id];
+      writeHiddenWorkers(next);
+      return next;
+    });
+  }
+
+  function unhideWorker(id: string): void {
+    setHiddenWorkerIds((prev) => {
+      const next = prev.filter((x) => x !== id);
+      writeHiddenWorkers(next);
+      return next;
+    });
+  }
+
+  const visibleWorkers = showHidden ? workers : workers.filter((w) => !hiddenWorkerIds.includes(w.id));
+
+  // Per-machine "models tested" / "tests performed" -- the app-wide stat
+  // cards above went platform-wide (see this file's own header comment), but
+  // a rig card still needs its OWN counts, which only this page's already-
+  // scoped runs/workers can answer.
+  const workerStats = useMemo(() => {
+    const map = new Map<string, { models: Set<string>; tests: number }>();
+    for (const w of workers) map.set(w.id, { models: new Set(), tests: 0 });
+    for (const r of runs) {
+      for (const w of workers) {
+        if (!testMatchesWorker(r, w)) continue;
+        const entry = map.get(w.id)!;
+        entry.models.add(r.model_id);
+        entry.tests += (r.items_done ?? 0) + (r.items_failed ?? 0) + (r.items_cancelled ?? 0);
+      }
+    }
+    return map;
+  }, [workers, runs]);
+
+  const selectedWorker = selectedWorkerId ? workers.find((w) => w.id === selectedWorkerId) : undefined;
+
+  const filteredRuns = useMemo(() => {
+    return runs.filter((r) => {
+      if (selectedWorker && !testMatchesWorker(r, selectedWorker)) return false;
+      if (hideFailed && r.status === "failed") return false;
+      if (hideCancelled && r.status === "cancelled") return false;
+      return true;
+    });
+  }, [runs, selectedWorker, hideFailed, hideCancelled]);
+
+  const recent = filteredRuns.slice(0, 8);
 
   return (
     <div>
       <h1 className="text-2xl font-semibold text-fg">Dashboard</h1>
 
-      <section className="grid grid-cols-2 gap-4 md:grid-cols-5">
-        <StatCard label="Users" value={userCount ?? "—"} />
-        <StatCard label="Machines" value={machinesEverConnected} />
-        <StatCard label="Models tested" value={distinctModelsTested} />
-        <StatCard label="Tests performed" value={testsTotal} />
-        <StatCard label="Total runs" value={totalRuns} />
+      <section className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+        <StatCard label="Users" value={stats?.users ?? "—"} />
+        <StatCard label="Machines" value={stats?.machines ?? "—"} />
+        <StatCard label="Models tested" value={stats?.modelsTested ?? "—"} />
+        <StatCard label="Quants options" value={stats?.quants ?? "—"} />
+        <StatCard label="Tests performed" value={stats?.tests ?? "—"} />
+        <StatCard label="Total runs" value={stats?.runs ?? "—"} />
       </section>
 
-      {loaded && workers.length === 0 ? (
-        <section className="mt-6 rounded-xl border border-border bg-surface px-6 py-8 text-center">
-          <p className="text-sm font-semibold text-fg">No machines yet.</p>
-          <p className="mt-1 text-sm text-muted">LlamaToaster runs benchmarks on your own hardware.</p>
-          <Link
-            to="/device"
-            className="mt-4 inline-block rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-accent-fg hover:bg-accent/90"
-          >
-            Connect your first machine
-          </Link>
-          <p className="mt-2 text-xs text-muted">Takes about a minute.</p>
-        </section>
-      ) : (
-        <section className="mt-6 grid gap-3 md:grid-cols-2">
-          {workers.map((w) => (
-            <MachineRow key={w.id} worker={w} />
-          ))}
-        </section>
-      )}
+      <section className="mt-6">
+        {workers.length > 0 && hiddenWorkerIds.length > 0 && (
+          <div className="mb-2 flex justify-end">
+            <label className="flex items-center gap-1.5 text-xs text-muted">
+              <input
+                type="checkbox"
+                checked={showHidden}
+                onChange={(e) => setShowHidden(e.target.checked)}
+                className="h-3.5 w-3.5 accent-accent"
+              />
+              Show hidden ({hiddenWorkerIds.length})
+            </label>
+          </div>
+        )}
+        {loaded && workers.length === 0 ? (
+          <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center">
+            <p className="text-sm font-semibold text-fg">No machines yet.</p>
+            <p className="mt-1 text-sm text-muted">LlamaToaster runs benchmarks on your own hardware.</p>
+            <Link
+              to="/device"
+              className="mt-4 inline-block rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-accent-fg hover:bg-accent/90"
+            >
+              Connect your first machine
+            </Link>
+            <p className="mt-2 text-xs text-muted">Takes about a minute.</p>
+          </div>
+        ) : visibleWorkers.length === 0 ? (
+          <div className="rounded-xl border border-border bg-surface px-6 py-8 text-center">
+            <p className="text-sm font-semibold text-fg">All machines are hidden.</p>
+            <button
+              type="button"
+              onClick={() => setShowHidden(true)}
+              className="mt-2 text-sm text-accent hover:underline"
+            >
+              Show hidden machines
+            </button>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {visibleWorkers.map((w) => {
+              const s = workerStats.get(w.id);
+              return (
+                <MachineCard
+                  key={w.id}
+                  worker={w}
+                  modelsTested={s?.models.size ?? 0}
+                  testsPerformed={s?.tests ?? 0}
+                  selected={selectedWorkerId === w.id}
+                  hidden={hiddenWorkerIds.includes(w.id)}
+                  onSelect={() => setSelectedWorkerId((cur) => (cur === w.id ? null : w.id))}
+                  onHide={() => hideWorker(w.id)}
+                  onUnhide={() => unhideWorker(w.id)}
+                />
+              );
+            })}
+          </div>
+        )}
+      </section>
 
       <section className="mt-8">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted">Recent tests</h2>
-        {loaded && recent.length === 0 && <p className="mt-2 text-sm text-muted">No tests yet.</p>}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted">Recent tests</h2>
+          <div className="flex flex-wrap items-center gap-4">
+            {selectedWorker && (
+              <button
+                type="button"
+                onClick={() => setSelectedWorkerId(null)}
+                className="flex items-center gap-1 rounded-lg border border-accent/40 bg-accent/10 px-2.5 py-1 text-xs font-medium text-accent hover:bg-accent/20"
+              >
+                {selectedWorker.displayName}
+                <IconX width={12} height={12} />
+              </button>
+            )}
+            <label className="flex items-center gap-1.5 text-xs text-muted">
+              <input
+                type="checkbox"
+                checked={hideFailed}
+                onChange={(e) => setHideFailed(e.target.checked)}
+                className="h-3.5 w-3.5 accent-accent"
+              />
+              Hide failed
+            </label>
+            <label className="flex items-center gap-1.5 text-xs text-muted">
+              <input
+                type="checkbox"
+                checked={hideCancelled}
+                onChange={(e) => setHideCancelled(e.target.checked)}
+                className="h-3.5 w-3.5 accent-accent"
+              />
+              Hide cancelled
+            </label>
+          </div>
+        </div>
+        {loaded && recent.length === 0 && (
+          <p className="mt-2 text-sm text-muted">{runs.length === 0 ? "No tests yet." : "No tests match the current filters."}</p>
+        )}
         <div className="mt-2 flex flex-col divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
           {recent.map((r) => (
             <Link

--- a/client/src/pages/Models.tsx
+++ b/client/src/pages/Models.tsx
@@ -356,6 +356,26 @@ export function Models() {
   // covers the next display page or the cursor runs out.
   const [hfPages, setHfPages] = useState<HfPage[]>(() => loadPersistedHfSearch()?.pages ?? []);
   const [hfPageIndex, setHfPageIndex] = useState(() => loadPersistedHfSearch()?.pageIndex ?? 0);
+  // Monotonic "search world" counter. Any change that invalidates already-fetched
+  // HF pages -- a fresh query/sort (runFreshHfSearch) or a params-filter change
+  // that re-chunks the filtered buffer -- bumps it. Every async fetch/fill path
+  // captures it before awaiting and refuses to commit its (now stale) result
+  // afterwards, so a slow in-flight pagination can never overwrite a newer
+  // search's pages or advance the page index past what the current filter
+  // actually matches (the "empty page" bug). See ensurePageFilled,
+  // goToNextHfPage and runFreshHfSearch.
+  const hfSearchEpochRef = useRef(0);
+  const bumpHfSearchEpoch = () => {
+    hfSearchEpochRef.current += 1;
+  };
+  // Count of user-triggered HF operations (fresh search / Next-page fill) still
+  // in flight. Only the LAST one to finish clears the `searching` flag -- if a
+  // superseded request drew its finally-run first, it mustn't re-enable the Next
+  // button while a newer search is still placing its page-0: a Next clicked into
+  // that gap would build on the half-replaced pages the epoch guard hasn't seen
+  // yet. With Next kept disabled for the whole overlap, fills can only ever
+  // start from a stable, current search world.
+  const hfBusyRef = useRef(0);
   const [expandedRepo, setExpandedRepo] = useState<string | null>(() => loadPersistedHfSearch()?.expandedRepo ?? null);
   const [filesByRepo, setFilesByRepo] = useState<Record<string, HfFileEntry[]>>(
     () => loadPersistedHfSearch()?.filesByRepo ?? {}
@@ -493,6 +513,17 @@ export function Models() {
   // Next" when Next is actually a dead end.
   const hasMoreHfPages =
     filteredHfResults.length > (hfPageIndex + 1) * HF_PAGE_SIZE || !!hfPages[hfPages.length - 1]?.nextCursor;
+  // Highest index the currently-filtered buffer can actually back a full page
+  // with -- a hard floor against structurally-empty pages. hfPageIndex only
+  // ever advances to a position the fill logic proved non-empty, but stale
+  // sessionStorage restores and the narrow window between a filter change and
+  // an in-flight commit could still point past the data; clamping here makes an
+  // empty display page impossible regardless of how the index got there.
+  const maxHfPageIndex = Math.max(0, Math.ceil(filteredHfResults.length / HF_PAGE_SIZE) - 1);
+
+  useEffect(() => {
+    setHfPageIndex((i) => Math.min(i, maxHfPageIndex));
+  }, [maxHfPageIndex]);
 
   async function loadModels() {
     setModels(await api.listModels());
@@ -918,6 +949,11 @@ export function Models() {
   // than reading hfSortField/hfSortDir off state so a control's own onChange
   // can pass its *new* value without waiting a render for state to catch up.
   async function runFreshHfSearch(field: HfSortField, dir: SortDir) {
+    // This replaces the entire search world -- any ensurePageFilled/Next fill
+    // still in flight belongs to the old one and must not commit afterwards.
+    bumpHfSearchEpoch();
+    const epoch = hfSearchEpochRef.current;
+    hfBusyRef.current += 1;
     setHfMsg("");
     setExpandedRepo(null);
     setSearching(true);
@@ -927,13 +963,18 @@ export function Models() {
         sort: HF_SORT_SERVER_FIELD[field],
         direction: field === "relevance" ? undefined : dir === "asc" ? 1 : -1,
       });
+      // A newer query/sort/filter took over while we were fetching -- don't
+      // stomp on its pages with this stale result.
+      if (hfSearchEpochRef.current !== epoch) return;
       setHfPages([{ results, nextCursor }]);
       setHfPageIndex(0);
       if (!results.length) setHfMsg("No repos found.");
     } catch (err) {
+      if (hfSearchEpochRef.current !== epoch) return;
       setHfMsg(`Search error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      setSearching(false);
+      hfBusyRef.current -= 1;
+      if (hfBusyRef.current <= 0) setSearching(false);
     }
   }
 
@@ -958,18 +999,27 @@ export function Models() {
   // set topped up, a page can only ever be non-full at the true end of the
   // results, never because a raw HF page happened to filter down to nothing.
   //
+  // `epoch` is the search world the caller started under; if it moves on
+  // mid-loop (fresh query/sort, or a filter change), the remaining fetches are
+  // abandoned -- they'd only be discarded by the caller's epoch guard anyway --
+  // so no more HF API calls are spent on a result set nobody is viewing.
+  //
   // Called from two places: goToNextHfPage (targeting the page it's about
   // to advance to) and the effect below (targeting whatever page is
   // *already* current -- covers landing on an under-filled page without any
   // Next click at all, e.g. right after a fresh search or a filter change,
   // which is exactly the "empty page" bug this whole redesign exists to fix).
-  async function ensurePageFilled(targetIndex: number): Promise<{ pages: HfPage[]; filteredCount: number }> {
+  async function ensurePageFilled(
+    targetIndex: number,
+    epoch: number
+  ): Promise<{ pages: HfPage[]; filteredCount: number; capped: boolean }> {
     let pages = hfPages;
     const filterFn = (r: HfRepoSearchResult) => paramsInRange(paramsBFromText(r.id), hfParamsLoIndex, hfParamsHiIndex);
     let filteredCount = pages.flatMap((p) => p.results).filter(filterFn).length;
     const needed = (targetIndex + 1) * HF_PAGE_SIZE;
     let attempts = 0;
     while (filteredCount < needed && pages[pages.length - 1]?.nextCursor && attempts < MAX_AUTO_FETCH_PAGES) {
+      if (epoch !== hfSearchEpochRef.current) break;
       const cursor = pages[pages.length - 1].nextCursor!;
       const { results, nextCursor } = await api.searchHf({
         q: hfQuery,
@@ -981,25 +1031,47 @@ export function Models() {
       filteredCount = pages.flatMap((p) => p.results).filter(filterFn).length;
       attempts++;
     }
-    return { pages, filteredCount };
+    // True only when the MAX_AUTO_FETCH_PAGES cap stopped the loop with the
+    // cursor still live (vs. the cursor genuinely running out) -- lets callers
+    // distinguish "there is genuinely nothing further" from "didn't dig far
+    // enough yet, keep clicking Next".
+    const capped =
+      attempts >= MAX_AUTO_FETCH_PAGES && filteredCount < needed && !!pages[pages.length - 1]?.nextCursor;
+    return { pages, filteredCount, capped };
   }
 
   async function goToNextHfPage() {
     setHfMsg("");
     setSearching(true);
+    hfBusyRef.current += 1;
+    const fromIndex = hfPageIndex;
+    const epoch = hfSearchEpochRef.current;
     try {
-      const newIndex = hfPageIndex + 1;
-      const { pages, filteredCount } = await ensurePageFilled(newIndex);
+      const { pages, filteredCount, capped } = await ensurePageFilled(fromIndex + 1, epoch);
+      // The query/sort/filter changed while the fill was fetching -- these
+      // pages belong to an old search world. Drop them rather than overwriting
+      // newer state (which could also advance the index past what the new,
+      // narrower filter matches, landing on a fully empty page).
+      if (hfSearchEpochRef.current !== epoch) return;
       if (pages !== hfPages) setHfPages(pages);
-      if (filteredCount > newIndex * HF_PAGE_SIZE) {
-        setHfPageIndex(newIndex);
+      if (filteredCount > (fromIndex + 1) * HF_PAGE_SIZE) {
+        setHfPageIndex(fromIndex + 1);
+      } else if (capped) {
+        // Reached MAX_AUTO_FETCH_PAGES with the cursor still live -- more
+        // matches are plausibly a fetch or two away, so don't declare the
+        // result set exhausted.
+        setHfMsg(
+          "Haven't pulled enough matching results yet -- click Next to keep looking, or widen the filter above."
+        );
       } else {
         setHfMsg("No further results match your parameter filter.");
       }
     } catch (err) {
+      if (hfSearchEpochRef.current !== epoch) return;
       setHfMsg(`Search error: ${err instanceof Error ? err.message : String(err)}`);
     } finally {
-      setSearching(false);
+      hfBusyRef.current -= 1;
+      if (hfBusyRef.current <= 0) setSearching(false);
     }
   }
 
@@ -1010,10 +1082,16 @@ export function Models() {
   // despite plenty of matches being just one more fetch away.
   useEffect(() => {
     let cancelled = false;
+    const epoch = hfSearchEpochRef.current;
     void (async () => {
       try {
-        const { pages } = await ensurePageFilled(hfPageIndex);
-        if (!cancelled) setHfPages((prev) => (pages === prev ? prev : pages));
+        const { pages } = await ensurePageFilled(hfPageIndex, epoch);
+        // `cancelled` covers this effect being torn down by a newer run; the
+        // epoch check additionally covers the search world changing without a
+        // re-run of this effect (e.g. a fresh query landing via runFreshHfSearch).
+        if (!cancelled && hfSearchEpochRef.current === epoch) {
+          setHfPages((prev) => (pages === prev ? prev : pages));
+        }
       } catch {
         // transient -- the user can still hit Next/Prev manually, which retries
       }
@@ -1720,6 +1798,10 @@ export function Models() {
                     // what the new, narrower filter leaves in the buffer --
                     // back to page 1, same as changing sort already does.
                     setHfPageIndex(0);
+                    // Bump the epoch too so any fill/advance that was mid-flight
+                    // under the previous filter can't commit stale pages or
+                    // re-advance the index afterwards.
+                    bumpHfSearchEpoch();
                   }}
                 />
               </label>
@@ -1765,6 +1847,7 @@ export function Models() {
                     setHfParamsLoIndex(0);
                     setHfParamsHiIndex(PARAMS_STOPS.length - 1);
                     setHfPageIndex(0);
+                    bumpHfSearchEpoch();
                   }}
                   className="rounded-lg border border-border px-3 py-1.5 text-sm text-muted hover:border-accent/40 hover:text-accent"
                 >

--- a/client/src/pages/Workers.tsx
+++ b/client/src/pages/Workers.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useWorkerStatuses } from "../api/useWorkerStatus";
+import { useDeviceEnrolment } from "../api/useDeviceEnrolment";
 import { WorkerCard } from "../components/WorkerCard";
 import { AddMachinePanel } from "../components/AddMachinePanel";
 import { IconChevronDown } from "../components/icons";
@@ -18,6 +19,23 @@ export function Workers() {
       .catch(() => setAuthEnabled(false));
   }, []);
 
+  // Lifted up (rather than left inside AddMachinePanel) so the compact code
+  // box next to the collapsed summary below and the full panel underneath
+  // share one code/status/approve state instead of drifting independently.
+  const enrolment = useDeviceEnrolment();
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  useEffect(() => {
+    if (loaded && order.length === 0) setDetailsOpen(true);
+  }, [loaded, order.length]);
+  // Once a typed code resolves to something the user needs to act on
+  // (pending confirmation, or an already-approved message), pop the panel
+  // open so they see it even if they typed the code while collapsed.
+  useEffect(() => {
+    if (enrolment.status?.state === "pending" || enrolment.status?.state === "approved" || enrolment.approved) {
+      setDetailsOpen(true);
+    }
+  }, [enrolment.status, enrolment.approved]);
+
   return (
     <div>
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -35,21 +53,41 @@ export function Workers() {
       {authEnabled && (
         <details
           className="group mt-4 rounded-xl border border-border bg-surface"
-          open={loaded && order.length === 0}
+          open={detailsOpen}
+          onToggle={(e) => setDetailsOpen(e.currentTarget.open)}
         >
           <summary className="flex cursor-pointer items-center gap-2 px-5 py-3 text-sm font-semibold text-fg select-none">
             Add a machine
             <span className="text-xs font-normal text-muted">
-              — connect a new GPU box by running one command on it
+              — connect your machine by running a single terminal command
             </span>
-            <IconChevronDown
-              width={14}
-              height={14}
-              className="ml-auto text-muted transition-transform group-open:rotate-180"
-            />
+            {/* Kept visible (and interactive) while the section is
+                collapsed, so a code from a headless setup can be entered
+                without expanding this whole panel first -- stopPropagation
+                keeps clicking/typing here from toggling the <details>. A
+                <span>, not a <div>, to stay within <summary>'s phrasing
+                content model while still getting flex layout from the
+                Tailwind class. */}
+            <span className="ml-auto flex items-center gap-3">
+              <input
+                type="text"
+                value={enrolment.codeInput}
+                onChange={(e) => enrolment.handleCodeChange(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                placeholder="ABCD-EFGH"
+                maxLength={9}
+                aria-label="Enrolment code"
+                className="w-32 rounded-lg border border-border bg-surface px-2.5 py-1 text-center font-mono text-xs uppercase tracking-widest text-fg outline-none focus:border-accent/50"
+              />
+              <IconChevronDown
+                width={14}
+                height={14}
+                className="text-muted transition-transform group-open:rotate-180"
+              />
+            </span>
           </summary>
           <div className="border-t border-border px-5 py-4">
-            <AddMachinePanel />
+            <AddMachinePanel enrolment={enrolment} />
           </div>
         </details>
       )}

--- a/server/src/routes/stats.test.ts
+++ b/server/src/routes/stats.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtempSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
+import type { AdminStats } from "../../../shared/types.js";
+
+// Operator request (following on from Multi-user Stage 5, MULTIUSER_PLAN.md
+// §5.2): GET /api/stats moved from a single unscoped user count to the full
+// cross-tenant AdminStats shape -- see this route's own file and client/src/
+// pages/Dashboard.tsx's header comment. No auth hook registered here, same
+// reasoning as models.test.ts: the route has no gate of its own, so this
+// exercises exactly what AUTH_ENABLED=off (or a public path) sees in
+// production.
+const tmpDir = mkdtempSync(join(tmpdir(), "llamatoaster-stats-route-test-"));
+process.env.DB_PATH = join(tmpDir, "test.db");
+
+let app: FastifyInstance;
+let baseUrl: string;
+let repo: typeof import("../db/repo.js")["repo"];
+
+beforeAll(async () => {
+  ({ repo } = await import("../db/repo.js"));
+  const { statsRoutes } = await import("./stats.js");
+
+  app = Fastify({ logger: false });
+  app.setErrorHandler((error: { statusCode?: number; message: string }, _req, reply) => {
+    reply.code(error.statusCode ?? 500).send({ error: error.message });
+  });
+  await app.register(statsRoutes);
+  await app.listen({ port: 0, host: "127.0.0.1" });
+  const address = app.server.address();
+  if (address === null || typeof address === "string") throw new Error("expected a bound TCP address");
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await app.close();
+  try {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    /* file still open -- fine, it's in the OS temp dir */
+  }
+});
+
+async function fetchStats(): Promise<AdminStats> {
+  return (await (await fetch(`${baseUrl}/api/stats`)).json()) as AdminStats;
+}
+
+describe("GET /api/stats", () => {
+  it("returns the full AdminStats shape, matching repo.adminRepo.stats() directly", async () => {
+    const body = await fetchStats();
+    expect(body).toEqual(repo.adminRepo.stats());
+  });
+
+  it("counts users across every account, not just one caller's own", async () => {
+    const before = await fetchStats();
+
+    repo.userRepo.upsertByIdentity("github", { providerUserId: "stats-route-user-a", login: "a", avatarUrl: null });
+    repo.userRepo.upsertByIdentity("github", { providerUserId: "stats-route-user-b", login: "b", avatarUrl: null });
+
+    const after = await fetchStats();
+    expect(after.users).toBe(before.users + 2);
+  });
+});

--- a/server/src/routes/stats.ts
+++ b/server/src/routes/stats.ts
@@ -1,12 +1,16 @@
 import type { FastifyInstance } from "fastify";
 import { repo } from "../db/repo.js";
 
-// The one intentionally cross-tenant number available on the main site
+// The intentionally cross-tenant numbers available on the main site
 // (outside the admin-only surface in routes/admin.ts) -- see client/src/
-// pages/Dashboard.tsx's own header comment for why a total user count is
-// the deliberate exception to that page's otherwise per-account scoping.
-// No auth gate of its own beyond whatever the global authMiddleware already
-// applies when AUTH_ENABLED -- it's just a count, no per-user data.
+// pages/Dashboard.tsx's own header comment for why its whole stat-card row
+// is platform-wide rather than scoped to the caller's own account. Reuses
+// adminRepo.stats() itself (same query as GET /api/admin/stats) rather than
+// a separate implementation -- these are the same numbers, just also
+// readable off the main origin. No auth gate of its own beyond whatever the
+// global authMiddleware already applies when AUTH_ENABLED -- it's all
+// aggregate counts, no per-user breakdown, so exposing it here carries the
+// same "just a count" reasoning that already justified the users total.
 export async function statsRoutes(app: FastifyInstance): Promise<void> {
-  app.get("/api/stats", async () => ({ users: repo.statsRepo.userCount() }));
+  app.get("/api/stats", async () => repo.adminRepo.stats());
 }


### PR DESCRIPTION
Three separable changes that were sitting uncommitted in the working tree.

- **`5da5b8b` Dashboard stat cards go platform-wide.** All six cards now come from one `GET /api/stats`, which serves `repo.adminRepo.stats()` directly rather than growing a second implementation. Aggregate counts only, no per-user breakdown. The machine list and "Recent tests" below stay caller-scoped; the cross-tenant table stays on the admin origin.
- **`82e2554` `useDeviceEnrolment` extracted from `AddMachinePanel`.** Lets `Workers.tsx` render a compact code box beside the collapsed summary, sharing one state with the full panel so the two can't drift.
- **`df62a53` HF search pagination race.** Epoch guard, in-flight counter and an index clamp, so a slow superseded fetch can no longer paint an empty results page.

### Why this should go in first

`main` currently **does not typecheck** — `server/src/routes/stats.ts` calls `repo.statsRepo.userCount()` and `statsRepo` does not exist on the repo object. The first commit here is the fix. Six dependabot PRs have merged on top of that broken state, hidden because Actions is billing-locked and no job has run.

### Verification

Local only — `ubuntu-latest` has not run, since the account is billing-locked.

- `npm run typecheck` clean
- `npm test` — 902/902 passing
- `npm run build` and `npm run build:admin` both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)