### PR TITLE
Drop redundant @types/uuid, unblock TypeScript 7, clear fast-uri advisories

### DIFF
--- a/admin/src/vite-env.d.ts
+++ b/admin/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
       "devDependencies": {
         "@types/adm-zip": "^0.5.8",
         "@types/better-sqlite3": "^9.6.0",
-        "@types/uuid": "^9.0.8",
         "typescript": "^5.5.4",
         "vitest": "^4.1.11"
       },
@@ -1054,13 +1053,6 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vitest/expect": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
@@ -1476,9 +1468,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",
@@ -1501,9 +1493,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "devDependencies": {
     "@types/adm-zip": "^0.5.8",
     "@types/better-sqlite3": "^9.6.0",
-    "@types/uuid": "^9.0.8",
     "typescript": "^5.5.4",
     "vitest": "^4.1.11"
   }


### PR DESCRIPTION
Dependency housekeeping falling out of the dependabot batch. No behaviour change.

### `@types/uuid` deleted (supersedes #14)

`uuid@14` declares its own `types` entry, so the stub has never been what resolved `import { v4 } from "uuid"`. #14 bumps it to `11.0.0`, which is a **deprecation stub** whose own published description says the package is unnecessary — merging it trades a real package for a warning on every `npm install`.

Deleting it is also what closes that PR permanently; dependabot reopens a plain close.

### `vite-env.d.ts` for both SPAs — prerequisite for #10, #11, #13

TypeScript 7 introduces `TS2882` for side-effect imports with no declarations, and both SPAs open `main.tsx` with `import "./styles/index.css"`. Neither project referenced `vite/client` anywhere, so under 7.x:

```
src/main.tsx(5,8): error TS2882: Cannot find module or type declarations
for side-effect import of './styles/index.css'.
```

`npm run build` fails outright — and since both SPAs are built from source at deploy time, that's a broken release, not just a red check. **Merge this before #10/#11/#13.** Nothing here changes anything under 5.x.

### `fast-uri` → 3.1.7 / 4.1.4

Lockfile only, `package.json` untouched. Transitive through fastify, clearing four high-severity advisories — two SSRF, two host confusion. Takes `npm audit` to 0 vulnerabilities.

### Verification

Local only — `ubuntu-latest` has not run, since the account is billing-locked.

- `npm run typecheck` clean, `npm test` 902/902, both SPA builds succeed
- re-verified with `typescript@7.0.2` installed in all three projects: both builds pass with these files, fail without them

🤖 Generated with [Claude Code](https://claude.com/claude-code)