### PR TITLE
Fix/llama server filler prompt

### DIFF
--- a/client/src/components/GoalQuestionnaire.tsx
+++ b/client/src/components/GoalQuestionnaire.tsx
@@ -1159,10 +1159,12 @@ function ModeCard({
           </span>
         )}
         {failedCapacity && <span className="block font-mono text-[11px] font-semibold text-danger">✗ didn’t fit</span>}
+        {/* The section-level warning banner above already carries the full
+            message once -- repeating it per card is redundant. This just
+            matches failedCapacity's own terse label; the "Test ↗" link
+            below (same as any other terminal card) is where the detail is. */}
         {failedUnsupported && (
-          <span className="block text-[10.5px] font-semibold leading-snug text-danger">
-            ✗ this model can't be tested — {result?.detail ?? "llama-server rejected its own output"}
-          </span>
+          <span className="block font-mono text-[11px] font-semibold text-danger">✗ can't be tested</span>
         )}
         {result?.status === "cancelled" && (
           <span className="block font-mono text-[11px] font-semibold text-muted">■ stopped before finishing</span>

--- a/client/src/pages/TestDetail.tsx
+++ b/client/src/pages/TestDetail.tsx
@@ -269,6 +269,8 @@ const CAVEAT_FLAG_REASON: Record<string, string> = {
     "a warm repeat re-prefilled the prompt, so the prefix cache did not hold and this point drops out of the curve",
   context_shift:
     "a context shift appeared in the logs and this build has no --no-context-shift, which silently corrupts TTFT comparability",
+  grammar_constrained:
+    "llama-server rejected this model's unconstrained output as invalid UTF-8, so the reading only came back under a sampling grammar -- the row is KEPT as a usable signal, but constrained sampling has its own overhead and this rate is not comparable with an unconstrained one",
 };
 
 const TERMINAL_ITEM_STATUSES = new Set([

--- a/docs/LLAMA_SERVER_VERBOSITY.md
+++ b/docs/LLAMA_SERVER_VERBOSITY.md
@@ -1,0 +1,108 @@
+# llama-server verbosity levels
+
+`--verbosity` is a `llama-server` (llama.cpp) flag, not a LlamaToaster setting. This
+doc compares what each level prints, and what LlamaToaster itself relies on and
+sets (`--verbosity 4`, plus `--metrics` for the `/metrics` endpoint). See
+[loadDriver.ts:96](../worker/src/loadDriver.ts:96) and
+[serverBench.ts:249](../worker/src/serverBench.ts:249) for where these are set.
+
+## The scale
+
+Per `llama-server --help`, confirmed live against the installed b10405 build
+(both at model load and mid-generation via a real `/completion` request —
+see [serverBench.ts:250](../worker/src/serverBench.ts:250)):
+
+| Level | Name | What it adds over the level below |
+|---|---|---|
+| 0 | generic | Startup banner, listen address, fatal errors only |
+| 1 | error | + error conditions (failed loads, bad requests) |
+| 2 | warning | + warnings (deprecated flags, recoverable issues) |
+| 3 | info (**default**) | + high-level lifecycle: server ready, model load start/finish, request accepted. **No per-tensor detail, no offload summary line.** |
+| 4 | trace | + `load_tensors: offloaded X/Y layers to GPU`, per-layer "layer N assigned to device" lines, slot lifecycle, context checkpoints, `print_timing` | 
+| 5 | debug | + per-token / per-draft-candidate trace — every generated token and (under MTP) every draft-candidate decision logged individually |
+
+Level 3 (the default) is not enough for LlamaToaster: it prints **none** of the
+offload-layer detail that [index.ts's `parseOffloadLayers`](../worker/src/index.ts)
+needs to report `gpu_layers_loaded`/`total_model_layers`
+(see [bench.ts:75-78](../worker/src/bench.ts:75)). That detail only appears at
+level 4+.
+
+Level 5 was tried first (as `999`, before this flag was tuned) and rejected:
+it floods the mirrored worker log with a per-token/per-draft-candidate trace
+that nothing in this app reads — see
+[serverBench.ts:258-261](../worker/src/serverBench.ts:258).
+
+**LlamaToaster always runs `llama-server` at `--verbosity 4`.** It's the
+lowest level that surfaces the offload line and everything else this app
+parses, while producing zero of level 5's noise.
+
+### llama-bench's equivalent
+
+`llama-bench` (the non-MTP benchmark path) doesn't have a numeric scale —
+just a boolean `-v`/`--verbose` flag, gated behind a runtime probe
+(`supportsVerboseFlag`, [bench.ts:81](../worker/src/bench.ts:81) — older
+builds don't support it). Off, it prints none of the per-tensor/offload
+detail either; on, it prints the same one-line-per-tensor load/repack spam
+and the same offload-summary line that llama-server prints at level 4
+(confirmed live — see [bench.ts:508-512](../worker/src/bench.ts:508)).
+
+### What LlamaToaster does with the level-4 output
+
+The raw stderr is always saved unfiltered to the per-item raw JSON dump,
+regardless of level. The worker's own text log is different: mirroring
+level-4 output there unfiltered used to bury the structured params/offload/
+summary lines this app logs for every test under tens of thousands of
+characters of tensor noise, so `logDiagnosticOutput` now mirrors it only at
+debug log level, and any single line over 300 chars is elided (to guard
+against a request/response body — including this app's own prompts/generated
+text — appearing verbatim in a trace-level line). See
+[index.ts:1295-1320](../worker/src/index.ts:1295).
+
+## `--metrics`: the `/metrics` endpoint
+
+Separately from `--verbosity`, `--metrics` turns on a Prometheus-format
+`/metrics` HTTP endpoint (not stderr logging at all — it's polled over HTTP
+while the server is up). llama-server's own metrics generally include
+per-slot/global counters like prompt and predicted token counts,
+prompt/predicted processing speed, KV-cache usage, and in-flight/deferred
+request counts — the exact set depends on the build.
+
+**LlamaToaster only reads two counters from it**, both spec-decode (MTP)
+related, matched by regex in
+[serverBench.ts:514-515](../worker/src/serverBench.ts:514):
+
+| Metric | LlamaToaster field | Purpose |
+|---|---|---|
+| `llamacpp:spec_decode_num_draft_tokens_total` | `spec_drafted` | How many tokens the draft (MTP) model proposed |
+| `llamacpp:spec_decode_num_accepted_tokens_total` | `spec_accepted` | How many of those the base model accepted |
+
+Together these confirm the draft model actually contributed to generation,
+rather than `--spec-type draft-mtp` silently no-opping (bad/incompatible
+`--model-draft` file, draft model failing to load while the base model still
+starts fine, etc — see [serverBench.ts:244-248](../worker/src/serverBench.ts:244)).
+
+Per llama-server's own doc comment, these two counters are **absent
+entirely** (not zeroed) until the first *completed* speculative request —
+LlamaToaster treats "missing from `/metrics`" as a distinct, reportable
+condition from "present but zero"
+([serverBench.ts:511-513](../worker/src/serverBench.ts:511),
+[serverBench.ts:532-535](../worker/src/serverBench.ts:532)): a fetch that
+returns no counters at all logs the warning *"MTP: /metrics reported no
+speculative-decoding counters — cannot confirm the draft model actually ran"*
+([serverBench.ts:554-556](../worker/src/serverBench.ts:554)).
+
+`/metrics` is queried once, right before the server is torn down (it's only
+reachable while `llama-server` is still running), and is treated as
+diagnostic-only — a failed or unreachable `/metrics` call never fails an
+otherwise-good benchmark run
+([serverBench.ts:526-528](../worker/src/serverBench.ts:526)).
+
+## Summary: what LlamaToaster actually launches with
+
+```
+llama-server ... --metrics --verbosity 4 --no-context-shift   # (last flag only if the build supports it)
+```
+
+- `--metrics` → poll `/metrics` once at the end for the two MTP spec-decode counters above.
+- `--verbosity 4` → the minimum level that prints the offload-layers line and per-tensor load detail this app parses, without level 5's per-token trace noise.
+- `--no-context-shift` → see the earlier chat answer / [shared/curves.ts:113](../shared/curves.ts:113); unrelated to verbosity, added conditionally after probing build support.

--- a/server/src/db/repo.ts
+++ b/server/src/db/repo.ts
@@ -1670,7 +1670,7 @@ export const repo = {
     const row = getDb()
       .prepare(
         `SELECT COUNT(*) as n FROM run_items
-         WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','cancelled','skipped')`
+         WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','failed_unsupported','cancelled','skipped')`
       )
       .get(runId) as { n: number };
     return row.n;
@@ -1763,7 +1763,7 @@ export const repo = {
       database
         .prepare(
           `UPDATE run_items SET status = 'failed', error = ?, completed_at = ?
-           WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','cancelled','skipped')`
+           WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','failed_unsupported','cancelled','skipped')`
         )
         .run(error, now, runId);
       this.finalizeTest(runId, now);
@@ -1791,7 +1791,7 @@ export const repo = {
       database
         .prepare(
           `UPDATE run_items SET status = 'cancelled', error = ?, completed_at = ?
-           WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','cancelled','skipped')`
+           WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','failed_unsupported','cancelled','skipped')`
         )
         .run(note, now, runId);
       this.finalizeTest(runId, now, note);
@@ -1821,7 +1821,7 @@ export const repo = {
       database
         .prepare(
           `UPDATE run_items SET status = 'failed', error = ?, completed_at = ?
-           WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','cancelled','skipped')`
+           WHERE run_id = ? AND status NOT IN ('done','failed','failed_oom','failed_unsupported','cancelled','skipped')`
         )
         .run(note, now, runId);
       this.finalizeTest(runId, now);
@@ -3001,10 +3001,10 @@ export const repo = {
       }
 
       // Terminal outcomes only -- the same finished set countUnfinishedItems
-      // defines ('done','failed','failed_oom','cancelled'); still-'queued' or
-      // in-flight items haven't been performed yet.
+      // defines ('done','failed','failed_oom','failed_unsupported','cancelled');
+      // still-'queued' or in-flight items haven't been performed yet.
       const tests = scalar(
-        `SELECT COUNT(*) AS n FROM run_items WHERE status IN ('done','failed','failed_oom','cancelled')`
+        `SELECT COUNT(*) AS n FROM run_items WHERE status IN ('done','failed','failed_oom','failed_unsupported','cancelled')`
       );
 
       return { users, machines, modelsTested, quants: quants.size, tests, runs };

--- a/server/src/routes/curves.test.ts
+++ b/server/src/routes/curves.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CURVE_METHOD_VERSION } from "../../../shared/types.js";
 import { mkdtempSync, existsSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -85,7 +86,7 @@ function result(testType: "pp" | "tg", tps: number, over: Record<string, unknown
     gpu_memory_model_peak_source: null,
     sample_count: 5,
     suspect_count: 0,
-    method_version: 2,
+    method_version: CURVE_METHOD_VERSION,
     ...over,
   };
 }
@@ -168,7 +169,7 @@ describe("GET /api/models/:id/curve (N1)", () => {
       points: { effectiveCtx: number; tg: number | null; ttftN: number | null }[];
       method_version: number;
     };
-    expect(body.method_version).toBe(2);
+    expect(body.method_version).toBe(CURVE_METHOD_VERSION);
     expect(body.points.map((p) => p.effectiveCtx)).toEqual([8192, 16384, 32768]);
     // Cold TTFT points are visibly single-shot.
     expect(body.points.every((p) => p.ttftN === 1)).toBe(true);

--- a/server/src/routes/measurements.test.ts
+++ b/server/src/routes/measurements.test.ts
@@ -539,8 +539,9 @@ describe("POST /api/runs/:id/probe-result (N2)", () => {
       config: { probe: { ...probeSpec, kv_pair: ["q5_1", "q5_1"] } },
     });
     const friendlyMessage =
-      "This model's output was rejected by llama-server as invalid -- testing can't run correctly for it on this build. " +
-      "This is a known llama.cpp limitation with 'thinking'/reasoning-style models (see ggml-org/llama.cpp#19869), not a hardware or configuration problem.";
+      "llama-server rejected this model's generated output as invalid: llama.cpp's chat-output parser fails a whole " +
+      "response over one invalid UTF-8 byte, and no server flag disables that check (ggml-org/llama.cpp#25072). " +
+      "This is an upstream llama.cpp limitation, not a hardware or configuration problem.";
     const res = await post(
       "/api/runs/probe-unsupported/probe-result",
       {
@@ -556,6 +557,13 @@ describe("POST /api/runs/:id/probe-result (N2)", () => {
     const item = repo.getTestItems("probe-unsupported")[0];
     expect(item.status).toBe("failed_unsupported");
     expect(item.error).toBe(friendlyMessage);
+    // Live-confirmed regression: countUnfinishedItems' own hardcoded terminal-
+    // status list (server/src/db/repo.ts) didn't originally include
+    // failed_unsupported, so finalizeTest was never called and the run stayed
+    // "running" forever even though its only item had gone terminal -- the UI
+    // kept showing a live elapsed timer for a run the worker had already
+    // completed and pushed a log for.
+    expect(repo.getTest(undefined, "probe-unsupported")?.status).toBe("failed");
   });
 });
 

--- a/server/src/routes/tests.ts
+++ b/server/src/routes/tests.ts
@@ -140,7 +140,7 @@ function validateSweep(sweep: unknown): string | null {
 }
 
 const TICK_STATUSES = new Set(["loading", "processing", "generating", "benchmarking"]);
-const TERMINAL_STATUSES = new Set(["done", "failed", "failed_oom", "cancelled", "skipped"]);
+const TERMINAL_STATUSES = new Set(["done", "failed", "failed_oom", "failed_unsupported", "cancelled", "skipped"]);
 const VALID_TEST_TYPES = new Set(["pp", "tg", "pg"]);
 const NUMERIC_RESULT_FIELDS = [
   "n_prompt",

--- a/shared/exchange.test.ts
+++ b/shared/exchange.test.ts
@@ -9,6 +9,12 @@ import {
   type Bundle,
   type BundleRow,
 } from "./exchange.js";
+import {
+  CURVE_METHOD_VERSION,
+  LEGACY_CURVE_METHOD_VERSION,
+  METHOD_VERSION,
+  SERVER_METHOD_VERSION,
+} from "./types.js";
 
 function bundleRow(over: Partial<BundleRow> = {}): BundleRow {
   return stampConfigHash({
@@ -93,9 +99,20 @@ describe("N7 export bundle", () => {
   });
 
   it("embeds a methods section keyed to the method version", () => {
-    expect(methodsFor(1).pipeline.join(" ")).toContain("stddev");
-    expect(methodsFor(2).summary).toContain("cold timed prefill");
-    expect(methodsFor(2).pipeline.join(" ")).toContain("cache_evicted");
+    expect(methodsFor(METHOD_VERSION).pipeline.join(" ")).toContain("stddev");
+    expect(methodsFor(CURVE_METHOD_VERSION).summary).toContain("cold timed prefill");
+    expect(methodsFor(CURVE_METHOD_VERSION).pipeline.join(" ")).toContain("cache_evicted");
+    // Server-measured rows say so, and say what the prompt was.
+    expect(methodsFor(SERVER_METHOD_VERSION).pipeline.join(" ")).toContain("mixed-register");
+    expect(methodsFor(SERVER_METHOD_VERSION).pipeline.join(" ")).toContain("grammar_constrained");
+    // A stored row from before the filler rewrite keeps its OWN description --
+    // relabelling it with today's pipeline would misdescribe shared data.
+    expect(methodsFor(LEGACY_CURVE_METHOD_VERSION).method_version).toBe(LEGACY_CURVE_METHOD_VERSION);
+    expect(methodsFor(LEGACY_CURVE_METHOD_VERSION).summary).toContain("before the filler prompt was rewritten");
+    expect(methodsFor(LEGACY_CURVE_METHOD_VERSION).pipeline.join(" ")).toContain("not comparable");
+    // llama-bench rows were never affected by the filler change; their section
+    // says why nothing about the prompt is ours to control.
+    expect(methodsFor(METHOD_VERSION).pipeline.join(" ")).toContain("builds its own prompt");
   });
 });
 

--- a/shared/exchange.ts
+++ b/shared/exchange.ts
@@ -5,7 +5,14 @@
 // exactly that row.
 
 import { configHash, type ConfigHashInput } from "./configHash.js";
-import type { CaveatFlag, TestType } from "./types.js";
+import {
+  CURVE_METHOD_VERSION,
+  LEGACY_CURVE_METHOD_VERSION,
+  METHOD_VERSION,
+  SERVER_METHOD_VERSION,
+  type CaveatFlag,
+  type TestType,
+} from "./types.js";
 import type { GoalsConfig } from "./goals.js";
 
 export const BUNDLE_FORMAT = "llamatoaster.bundle";
@@ -118,9 +125,12 @@ export interface MethodsSection {
 // Every shared number carries its own methods section. Keyed to
 // method_version so a mixed-vintage bundle explains both vintages.
 export function methodsFor(methodVersion: number): MethodsSection {
-  if (methodVersion >= 2) {
+  // Ordered newest first, and every historical vintage keeps its own section:
+  // this describes what a STORED row was measured by, so relabelling an old
+  // row with today's pipeline would be a lie about data already shared.
+  if (methodVersion >= CURVE_METHOD_VERSION) {
     return {
-      method_version: 2,
+      method_version: CURVE_METHOD_VERSION,
       summary:
         "Context-curve choreography: a discarded warm-up on a nonce prompt, one cold timed prefill whose first streamed chunk is the TTFT reading, then warm repeats against the prefix cache for generation statistics.",
       pipeline: [
@@ -130,16 +140,48 @@ export function methodsFor(methodVersion: number): MethodsSection {
         "warm repeats: identical prompt with cache_prompt -- any repeat reporting prompt_n > 0 re-prefilled and flags cache_evicted",
         "implausibility filter rejects physically impossible rates; wall-clock fallback readings are marked suspect",
         "stability gate: stddev <= max(10 % of mean, 0.5 tok/s), n >= 3",
+        "filler prompt: a tokenized mixed-register passage (prose, code, equations, structured data, non-Latin scripts), every register holding an equal share of the prompt at every size and interleaved below the ubatch so each batch sees all of them",
+      ],
+    };
+  }
+  if (methodVersion === LEGACY_CURVE_METHOD_VERSION) {
+    return {
+      method_version: LEGACY_CURVE_METHOD_VERSION,
+      summary:
+        "Context-curve choreography, measured before the filler prompt was rewritten: a discarded warm-up on a nonce prompt, one cold timed prefill whose first streamed chunk is the TTFT reading, then warm repeats against the prefix cache for generation statistics.",
+      pipeline: [
+        "warm-up: a short nonce prompt, n_predict 8, excluded from statistics by construction",
+        "cold timed prefill: full prompt, streamed, n_predict 1, ignore_eos -- first-chunk arrival is TTFT (single sample, labeled as such)",
+        "pp for the point comes from that same response's timings.prompt_ms / prompt_n",
+        "warm repeats: identical prompt with cache_prompt -- any repeat reporting prompt_n > 0 re-prefilled and flags cache_evicted",
+        "implausibility filter rejects physically impossible rates; wall-clock fallback readings are marked suspect",
+        "stability gate: stddev <= max(10 % of mean, 0.5 tok/s), n >= 3",
+        "filler prompt: a low-entropy synthetic token range -- on a mixture-of-experts model with experts on CPU this reads well above a realistic prompt, so prefill from this vintage is not comparable with later rows",
+      ],
+    };
+  }
+  if (methodVersion >= SERVER_METHOD_VERSION) {
+    return {
+      method_version: SERVER_METHOD_VERSION,
+      summary:
+        "Measured through llama-server rather than llama-bench: a streamed request lifecycle, and a synthetic prompt this project controls. Split from the core vintage when that prompt became a mixed-register passage -- on a mixture-of-experts model with experts on CPU, the previous low-entropy filler collapsed expert routing and read 70% above llama-bench on the same model and flags.",
+      pipeline: [
+        "filler prompt: a tokenized mixed-register passage (prose, code, equations, structured data, non-Latin scripts), every register holding an equal share of the prompt at every size and interleaved below the ubatch so each batch sees all of them",
+        "greedy decoding (temperature 0) with ignore_eos, so a repeat is reproducible and both engines decode the same number of tokens",
+        "a rejected generation is retried on a rotated prompt, then once under a grammar; a reading that needed the grammar is flagged grammar_constrained",
+        "implausibility filter rejects physically impossible rates; suspect readings are kept and flagged, never silently erased",
+        "sample (n-1) standard deviation, matching llama-bench's own formula",
       ],
     };
   }
   return {
-    method_version: 1,
+    method_version: METHOD_VERSION,
     summary:
       "Core methodology: warmed benchmark repeats, streamed clock where the engine has a request lifecycle, an implausibility filter on both sides of any pair, and a stddev floor in the stability gate.",
     pipeline: [
       "warm-up before the timed repeats",
       "streamed clock on the llama-server path; llama-bench does its own internal repeat averaging",
+      "llama-bench builds its own prompt internally (uniformly random vocabulary ids), which this project cannot supply or change",
       "implausibility filter rejects physically impossible rates (the ~1e6 tok/s timer-bug class)",
       "suspect readings are kept and flagged, never silently erased",
       "sample (n-1) standard deviation, matching llama-bench's own formula",

--- a/shared/scoring.ts
+++ b/shared/scoring.ts
@@ -331,13 +331,14 @@ export function scoreProfiles(input: ScoringInput): ScoringResult {
     const ppRows = bucket.rows.filter((r) => r.test_type === "pp");
     const tgRows = bucket.rows.filter((r) => r.test_type === "tg");
 
-    // A failed/failed_oom item in the tuple's sub-run disqualifies it; a
-    // `skipped` item does not -- it was never measured. Both land in the
-    // missing_pp_or_tg tally, which is the closed registry's bucket for "this
-    // tuple never produced the pair scoring needs".
+    // A failed/failed_oom/failed_unsupported item in the tuple's sub-run
+    // disqualifies it; a `skipped` item does not -- it was never measured.
+    // Both land in the missing_pp_or_tg tally, which is the closed
+    // registry's bucket for "this tuple never produced the pair scoring
+    // needs".
     const itemFailed = bucket.rows.some((r) => {
       const status = input.itemStatusByIdx?.[r.idx];
-      return status === "failed" || status === "failed_oom";
+      return status === "failed" || status === "failed_oom" || status === "failed_unsupported";
     });
     if (itemFailed || ppRows.length === 0 || tgRows.length === 0) {
       tallies.missing_pp_or_tg++;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -147,7 +147,22 @@ export const METHOD_VERSION = 1;
 // statistics) are a real semantics change under §0.1, so they stamp this
 // instead -- which is also what keeps ordinary runtime rows' warm-biased TTFT
 // out of curves without a dedicated marker column.
-export const CURVE_METHOD_VERSION = 2;
+export const CURVE_METHOD_VERSION = 4;
+
+// Rows measured THROUGH llama-server (N5's concurrency ladder and the MTP
+// path). Split out from METHOD_VERSION when the synthetic filler prompt became
+// a tokenized mixed-register passage: on a mixture-of-experts model with
+// experts on CPU, that change alone moved measured prefill by 58% (the old
+// filler collapsed expert routing and read 70% above llama-bench on the same
+// model and flags). llama-bench builds its own prompt internally, so its rows
+// are untouched by that change and stay at METHOD_VERSION -- bumping the
+// shared constant would have falsely invalidated them.
+export const SERVER_METHOD_VERSION = 3;
+
+// The curve vintage that shipped before the filler-prompt rewrite. Kept as a
+// named constant because stored rows still carry it and N7 bundles still have
+// to describe how they were measured.
+export const LEGACY_CURVE_METHOD_VERSION = 2;
 
 // N2 added 'probe'; N4's quality measurement gets its own kind too, for the
 // same reason -- a single perplexity measurement is not a sweep, and folding
@@ -178,6 +193,12 @@ export const CAVEAT_FLAGS = [
   "thermally_throttled",
   "cache_evicted",
   "context_shift",
+  // The reading only came back at all because generation was constrained by a
+  // grammar -- llama.cpp's chat-output parser rejects any response containing
+  // one invalid UTF-8 byte, and some models emit one unprompted. Constrained
+  // sampling carries its own overhead, so such a row is a usable signal but
+  // not directly comparable with an unconstrained one.
+  "grammar_constrained",
 ] as const;
 export type CaveatFlag = (typeof CAVEAT_FLAGS)[number];
 

--- a/worker/src/fillerPrompt.test.ts
+++ b/worker/src/fillerPrompt.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildPromptTokens, fetchFillerBlocks, type FillerBlocks } from "./fillerPrompt.js";
+
+// Five blocks of distinct, non-overlapping id ranges: which block a token came
+// from is then readable straight off its value, which is what lets these tests
+// assert on the register MIX rather than just on counts.
+const BLOCKS: FillerBlocks = [
+  Array.from({ length: 37 }, (_, i) => 1000 + i),
+  Array.from({ length: 53 }, (_, i) => 2000 + i),
+  Array.from({ length: 41 }, (_, i) => 3000 + i),
+  Array.from({ length: 61 }, (_, i) => 4000 + i),
+  Array.from({ length: 29 }, (_, i) => 5000 + i),
+];
+
+const blockOf = (token: number) => Math.floor(token / 1000);
+
+function shares(tokens: number[]): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const t of tokens) counts.set(blockOf(t), (counts.get(blockOf(t)) ?? 0) + 1);
+  return counts;
+}
+
+describe("filler prompt construction", () => {
+  it("produces exactly the requested token count", () => {
+    for (const n of [0, 1, 7, 64, 768, 8192]) {
+      expect(buildPromptTokens(n, 0, 0, BLOCKS)).toHaveLength(n);
+    }
+  });
+
+  it("only ever emits ids that came from the blocks", () => {
+    const all = new Set(BLOCKS.flat());
+    expect(buildPromptTokens(2048, 3, 2, BLOCKS).every((t) => all.has(t))).toBe(true);
+  });
+
+  // The register mix has to be identical at every prompt size, or N1's curve
+  // conflates depth scaling with a drifting content mix -- and content is worth
+  // up to 58% on MoE prefill.
+  it("gives every block the same share of the prompt at every size", () => {
+    for (const n of [512, 4096, 32_768]) {
+      const counts = shares(buildPromptTokens(n, 0, 0, BLOCKS));
+      expect(counts.size).toBe(BLOCKS.length);
+      const each = [...counts.values()];
+      // Equal to within the remainder spread across the leading blocks.
+      expect(Math.max(...each) - Math.min(...each)).toBeLessThanOrEqual(1);
+      expect(each.reduce((a, b) => a + b, 0)).toBe(n);
+    }
+  });
+
+  // Prefill computes its expert union per ubatch (512). Contiguous blocks would
+  // put one register in each ubatch at large sizes and read ~3% fast.
+  it("interleaves finely enough that every ubatch-sized window sees every block", () => {
+    const tokens = buildPromptTokens(4096, 0, 0, BLOCKS);
+    for (let start = 0; start + 512 <= tokens.length; start += 512) {
+      expect(shares(tokens.slice(start, start + 512)).size).toBe(BLOCKS.length);
+    }
+  });
+
+  it("gives each nonce a distinct sequence, so the prefix cache cannot dedupe streams", () => {
+    const a = buildPromptTokens(64, 0, 1, BLOCKS);
+    const b = buildPromptTokens(64, 0, 2, BLOCKS);
+    expect(a).not.toEqual(b);
+    // Distinct from the very first token: a shared prefix is exactly what would
+    // let a later stream read artificially fast.
+    expect(a[0]).not.toBe(b[0]);
+  });
+
+  // N5 spaces nonces as `nonce + repeat * 1000`.
+  it("keeps N5's repeat-spaced nonces distinct", () => {
+    const prompts = new Set(
+      [0, 1000, 2000, 3000].map((nonce) => buildPromptTokens(128, 0, nonce, BLOCKS).join(","))
+    );
+    expect(prompts.size).toBe(4);
+  });
+
+  it("gives each retry offset a distinct sequence, so a retry is not a replay", () => {
+    expect(buildPromptTokens(256, 0, 0, BLOCKS)).not.toEqual(buildPromptTokens(256, 137, 0, BLOCKS));
+  });
+
+  it("keeps the mix fixed while rotating, so a retry changes order and not composition", () => {
+    const plain = shares(buildPromptTokens(1024, 0, 0, BLOCKS));
+    const rotated = shares(buildPromptTokens(1024, 137, 3, BLOCKS));
+    expect([...rotated.entries()].sort()).toEqual([...plain.entries()].sort());
+  });
+
+  it("still fills the prompt when a block tokenized to nothing", () => {
+    const withEmpty: FillerBlocks = [BLOCKS[0], [], BLOCKS[2]];
+    const tokens = buildPromptTokens(300, 0, 0, withEmpty);
+    expect(tokens).toHaveLength(300);
+    expect(shares(tokens).size).toBe(2);
+  });
+
+  it("refuses to build a prompt with no usable blocks", () => {
+    expect(() => buildPromptTokens(64, 0, 0, [])).toThrow(/no usable token blocks/);
+    expect(() => buildPromptTokens(64, 0, 0, [[], []])).toThrow(/no usable token blocks/);
+  });
+});
+
+describe("fetchFillerBlocks", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns one tokenized block per register, asking the server not to add special tokens", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init: RequestInit) => {
+        calls.push(String(init.body));
+        return Response.json({ tokens: [11, 22, 33] });
+      })
+    );
+    const blocks = await fetchFillerBlocks(8080);
+    expect(blocks.length).toBeGreaterThanOrEqual(5);
+    expect(blocks.every((b) => b.length === 3)).toBe(true);
+    expect(calls.every((b) => JSON.parse(b).add_special === false)).toBe(true);
+  });
+
+  // A silent fallback would emit a number measured against different content,
+  // and that number can be 70% off. An incomparable row is worse than a failure.
+  it("throws rather than degrading when the endpoint is unusable", async () => {
+    for (const [stub, pattern] of [
+      [
+        async () => {
+          throw new Error("connect ECONNREFUSED");
+        },
+        /request failed/,
+      ],
+      [async () => new Response("nope", { status: 404 }), /returned 404/],
+      [async () => Response.json({ tokens: "not an array" }), /returned no tokens/],
+      [async () => Response.json({ tokens: [] }), /tokenized to nothing/],
+    ] as const) {
+      vi.stubGlobal("fetch", vi.fn(stub));
+      await expect(fetchFillerBlocks(8080)).rejects.toThrow(pattern);
+    }
+  });
+});

--- a/worker/src/fillerPrompt.ts
+++ b/worker/src/fillerPrompt.ts
@@ -1,0 +1,197 @@
+// The synthetic filler prompt every llama-server-driven benchmark sends.
+//
+// Prompts go out PRE-TOKENIZED (an array of token ids, not a string) because
+// these benchmarks are defined by an exact token count -- the same semantics
+// llama-bench's own `-p N` has. A text string would make the count tokenizer-
+// dependent, so the count is chosen and the ids are supplied directly.
+//
+// Two separate properties have to hold, and each was expensive to learn.
+//
+// --- 1. The ids must decode to VALID UTF-8 --------------------------------
+//
+// llama.cpp's chat-output PEG parser (common/peg-parser.cpp) hard-fails a whole
+// response the instant one byte sequence is classified INVALID UTF-8: the "any
+// codepoint" primitive underlying rest()/content() -- what even the trivial
+// always-succeed Content-only grammar is built from -- returns an unconditional
+// FAIL there, without consulting the parser's lenient flag. llama-server runs
+// that parser over /completion output too, so the request comes back as
+//
+//   {"error":{"code":500,"message":"The model produced output that does not
+//    match the expected Content-only format"}}
+//
+// with no timings at all. No request field or server flag makes it tolerant --
+// confirmed live against b10793 that --reasoning-format, -rea off,
+// --skip-chat-parsing and --reasoning-budget all still hit it (upstream
+// ggml-org/llama.cpp#25072).
+//
+// The filler used to be an arithmetic range of ids starting at 100. In a
+// byte-BPE vocabulary (gpt2-style pre-tokenizer: Qwen, Llama 3 and friends) ids
+// ~94-255 are the RAW SINGLE BYTE tokens, including the 0x80-0xFF ones that are
+// not valid UTF-8 alone -- /detokenize returns nothing but U+FFFD for that
+// range. Under greedy decoding the model answers that in kind: reproduced live
+// on Qwen3.8-27B, where the first generated token (n_predict=1 suffices) was the
+// byte pair 8C 80, a bare continuation sequence, failing the parser before a
+// single content frame was sent. Tokenizing real text instead makes the ids
+// valid UTF-8 pieces by construction, in whatever vocabulary the model has.
+//
+// --- 2. The text must READ LIKE REAL, MIXED CONTENT -----------------------
+//
+// On a mixture-of-experts model with experts on CPU (--n-cpu-moe), prompt
+// content changes measured PREFILL speed by up to 58%. Prefill processes a whole
+// batch at once, so the batch must read every expert ANY token in it routes to;
+// low-entropy input collapses routing onto few experts and reads
+// unrealistically fast. Generation decodes one token at a time and always
+// touches exactly n_expert_used experts, which is why tg is unaffected.
+//
+// Measured live on Qwen3.6-35B-A3B (--n-cpu-moe 99, pp768, 5 interleaved rounds,
+// llama-bench on the same model and flags = 132.8 tok/s as the reference):
+//
+//   38-word soup, 20 distinct ids ....... 225.6 tok/s   (+70% vs llama-bench)
+//   English prose only .................. 142.7 tok/s   (+7%)
+//   these 5 blocks ...................... 130.0 tok/s   (-2%)
+//   + chat, logs, CSV (8 blocks) ........ 129.8 tok/s   (-2%)
+//   + 4 more scripts, XML/YAML (10) ..... 130.7 tok/s   (-2%)
+//
+// So it saturates at five registers -- doubling them moves nothing. Distinct
+// token count is NOT the variable (34-distinct prose and 329-distinct prose
+// measure identically; 765 distinct tokens of synthetic word soup read 14%
+// fast); how far the batch's hidden states diverge is.
+//
+// Deliberately NOT adding more scripts: a model whose vocabulary doesn't cover
+// one tokenizes it by byte fallback, putting raw byte fragments back into the
+// prompt -- the exact condition described in part 1. Qwen covers Cyrillic and
+// Chinese natively; a narrower vocabulary might not, and the extra scripts buy
+// nothing measurable.
+
+/** One register each. Changing these changes what the benchmarks measure. */
+const FILLER_BLOCKS: readonly string[] = [
+  // Narrative prose.
+  "The harbour master logged every vessel clearing the northern channel before dawn, " +
+    "noting tonnage, draught and destination in a ledger whose columns had not changed " +
+    "since the war. Gulls worked the wake of returning trawlers while gantry cranes swung " +
+    "containers onto flatbed rail cars bound for the interior provinces.",
+  // Source code, two languages plus SQL.
+  "export async function fetchWithRetry(url: string, attempts = 3): Promise<Response> {\n" +
+    "  for (let i = 0; i < attempts; i++) {\n" +
+    "    try { const res = await fetch(url); if (!res.ok) throw new Error(`HTTP ${res.status}`); return res; }\n" +
+    "    catch (err) { await new Promise(r => setTimeout(r, 2 ** i * 100)); }\n" +
+    "  }\n" +
+    "}\n" +
+    "SELECT worker_id, COUNT(*) AS n FROM results WHERE test_type = 'pp' GROUP BY worker_id HAVING n >= 5;",
+  // Mathematics: symbols, digits, notation.
+  "Let f(x) = integral from 0 to x of e^(-t^2) dt, so f'(x) = e^(-x^2). For n >= 1, " +
+    "sum k^3 = (n(n+1)/2)^2. sigma^2 = 14.2857 gives sigma = 3.7796 and a 95% CI of " +
+    "[12.41, 19.87]. Matrix [[2,-1,0],[-1,2,-1],[0,-1,2]] has eigenvalues 2 - sqrt(2), 2, 2 + sqrt(2).",
+  // Structured data.
+  '{"worker":"rig-04","gpu":"RX 6600 XT","vram_mib":8176,"results":[{"test":"pp768","tps":132.84}]}\n' +
+    "| model | ngl | pp768 | tg16 |\n|---|---|---|---|\n| 35B-A3B | 99 | 132.84 | 14.09 |",
+  // Non-Latin scripts, both natively covered by the vocabularies this targets.
+  "Портовый смотритель записывал каждое судно, прошедшее северный канал до рассвета.\n" +
+    "港务长在黎明前记录了每一艘通过北部航道的船只，注明吨位和目的地。",
+];
+
+// Stride between nonces. Prime, so distinct nonces land on distinct rotations
+// of any block whose length isn't a multiple of it.
+const NONCE_STRIDE = 7919;
+
+// How many consecutive tokens one block contributes before the next block takes
+// over. Must stay well below llama-server's ubatch (512) so EVERY prefill batch
+// sees every register -- laying the blocks out contiguously instead segregates
+// one register per ubatch at large prompt sizes and reads ~3% fast (measured at
+// n_prompt 2560, where 5 contiguous blocks fall one per ubatch exactly).
+const INTERLEAVE_CHUNK = 64;
+
+const TOKENIZE_TIMEOUT_MS = 30_000;
+
+/** A tokenized filler block per FILLER_BLOCKS entry, in the same order. */
+export type FillerBlocks = number[][];
+
+/**
+ * Asks the running llama-server to tokenize each filler block, giving ids that
+ * are valid UTF-8 pieces IN THAT MODEL'S OWN VOCABULARY.
+ *
+ * Throws rather than falling back to anything. A silent fallback would emit a
+ * number measured against different content, and the measurements above show
+ * that number can be 70% off -- an incomparable row in the database is worse
+ * than a failed test. The server has already passed its health check by the
+ * time this runs, so failure here is genuinely exceptional.
+ */
+export async function fetchFillerBlocks(port: number): Promise<FillerBlocks> {
+  const blocks = await Promise.all(
+    FILLER_BLOCKS.map(async (content, i) => {
+      let res: Response;
+      try {
+        res = await fetch(`http://127.0.0.1:${port}/tokenize`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          // No BOS/EOS: those are special tokens, and this is filler, not a turn.
+          body: JSON.stringify({ content, add_special: false }),
+          signal: AbortSignal.timeout(TOKENIZE_TIMEOUT_MS),
+        });
+      } catch (err) {
+        throw new Error(
+          `filler prompt: /tokenize request failed for block ${i}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      if (!res.ok) throw new Error(`filler prompt: /tokenize returned ${res.status} for block ${i}`);
+      const data = (await res.json()) as { tokens?: unknown };
+      if (!Array.isArray(data.tokens)) throw new Error(`filler prompt: /tokenize returned no tokens for block ${i}`);
+      const tokens = data.tokens.filter((t): t is number => typeof t === "number" && Number.isFinite(t));
+      if (tokens.length === 0) throw new Error(`filler prompt: block ${i} tokenized to nothing`);
+      return tokens;
+    })
+  );
+  return blocks;
+}
+
+/**
+ * A synthetic prompt of exactly `tokenCount` tokens.
+ *
+ * Every block gets an equal share of the total (the remainder spread across the
+ * leading blocks), so the register mix is IDENTICAL at 512 tokens and at 32768.
+ * That matters because N1 curves measure prefill at increasing depths: if the
+ * mix drifted with size, the curve would conflate depth scaling with a changing
+ * content mix, and content is worth up to 58% on MoE.
+ *
+ * `offset` and `nonce` both rotate each block WITHIN its own share, so the mix
+ * is preserved while the sequence still differs. `nonce` gives N5's concurrent
+ * streams (and N1's warm/discard request) prompts the prefix cache cannot
+ * dedupe; `offset` is the retry knob -- a request that tripped the parser bug is
+ * retried with a different offset rather than replayed byte-for-byte, which
+ * under greedy decoding would fail identically.
+ */
+export function buildPromptTokens(
+  tokenCount: number,
+  offset = 0,
+  nonce = 0,
+  blocks: FillerBlocks
+): number[] {
+  const count = Math.max(0, Math.trunc(tokenCount));
+  if (count === 0) return [];
+  const usable = blocks.filter((b) => b.length > 0);
+  if (usable.length === 0) throw new Error("filler prompt: no usable token blocks");
+
+  const base = Math.floor(count / usable.length);
+  const extra = count % usable.length;
+  const remaining = usable.map((_, i) => base + (i < extra ? 1 : 0));
+  const start = offset + nonce * NONCE_STRIDE;
+  const cursor = usable.map((b) => ((start % b.length) + b.length) % b.length);
+
+  const out: number[] = [];
+  while (out.length < count) {
+    let progressed = false;
+    for (let i = 0; i < usable.length; i++) {
+      const take = Math.min(INTERLEAVE_CHUNK, remaining[i]);
+      for (let j = 0; j < take; j++) {
+        out.push(usable[i][cursor[i]]);
+        cursor[i] = (cursor[i] + 1) % usable[i].length;
+      }
+      remaining[i] -= take;
+      if (take > 0) progressed = true;
+    }
+    // Defensive: shares sum to `count`, so this can only fire if every block
+    // is exhausted, which would mean the arithmetic above is wrong.
+    if (!progressed) break;
+  }
+  return out;
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -26,6 +26,7 @@ import { spawn } from "node:child_process";
 import {
   spawnRuntimeServer,
   streamedCompletion,
+  completeWithRetries,
   executeCurvePoint,
   executeKneeLadder,
   probeSucceeded,
@@ -42,7 +43,8 @@ import {
   PROBE_MAX_LOADS,
   type LadderAttempt,
 } from "../../shared/probeLadder.js";
-import { buildPromptTokens, DEFAULT_KNEE_SLOTS } from "./loadDriver.js";
+import { DEFAULT_KNEE_SLOTS } from "./loadDriver.js";
+import { fetchFillerBlocks } from "./fillerPrompt.js";
 import { supportsFlag } from "./binary-probe.js";
 import { MemorySampler, captureFreeMemoryBaseline, type SampleStats, type FreeMemoryBaseline } from "./sampler.js";
 import { readGpuMemory, readNvidiaDriverInfo, type NvidiaDriverInfo } from "./vram.js";
@@ -3438,12 +3440,29 @@ async function runOneProbeLoad(input: ProbeLoadInput): Promise<ProbeAttemptOutco
         sampler.start(proc.pid, payload.llama_cpp_backend, TICK_INTERVAL_MS);
       },
     });
-    const sample = await streamedCompletion({
+    // Retries a rejected generation on a rotated prompt, and falls back to a
+    // grammar-constrained attempt, rather than letting one parser failure mark
+    // the whole ladder fatal (see completeWithRetries).
+    const { sample, grammarConstrained } = await completeWithRetries({
+      completion: streamedCompletion,
       port: server.port,
-      promptTokens: buildPromptTokens(64),
+      tokenCount: 64,
+      offset: 0,
+      nonce: 0,
+      blocks: await fetchFillerBlocks(server.port),
       nPredict: PROBE_GEN_TOKENS,
       cachePrompt: false,
+      log,
     });
+    if (grammarConstrained) {
+      // The rung still answers what the probe asks -- does this placement load
+      // and generate -- but its rate carries constrained-sampling overhead, so
+      // it is not a throughput reading anyone should compare.
+      log.warn(
+        `${input.label}: this configuration only generated under a grammar constraint; ` +
+          `treating it as usable, but its ${PROBE_GEN_TOKENS}-token rate is not comparable`
+      );
+    }
     const genTps =
       sample.e2eMs > sample.ttftMs && sample.tokensPredicted > 0
         ? (sample.tokensPredicted / (sample.e2eMs - sample.ttftMs)) * 1000

--- a/worker/src/loadDriver.test.ts
+++ b/worker/src/loadDriver.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  buildPromptTokens,
   buildServerArgs,
   contextSizeForSlots,
   curveCaveatFlags,
@@ -13,6 +12,7 @@ import {
   summarizeStreams,
   type StreamSample,
 } from "./loadDriver.js";
+import { buildPromptTokens } from "./fillerPrompt.js";
 
 const item = {
   threads: 8,
@@ -67,21 +67,6 @@ describe("server arguments for the spec-off engine pair", () => {
       supportsNoContextShift: true,
     });
     expect(with_).toContain("--no-context-shift");
-  });
-});
-
-describe("prompt construction", () => {
-  it("produces exactly the requested token count", () => {
-    expect(buildPromptTokens(8192)).toHaveLength(8192);
-  });
-
-  it("gives each nonce a distinct sequence, so the prefix cache cannot dedupe streams", () => {
-    const a = buildPromptTokens(64, 0, 1);
-    const b = buildPromptTokens(64, 0, 2);
-    expect(a).not.toEqual(b);
-    // Distinct from the very first token: a shared prefix is exactly what
-    // would let a later stream read artificially fast.
-    expect(a[0]).not.toBe(b[0]);
   });
 });
 
@@ -226,7 +211,7 @@ describe("N5 concurrent batch", () => {
     expect(new Set(batch.map((s) => s.nonce)).size).toBe(4);
     // Never nonce 0 -- that is the measured curve prompt.
     expect(batch.every((s) => s.nonce !== 0)).toBe(true);
-    const prompts = batch.map((s) => buildPromptTokens(8, 0, s.nonce).join(","));
+    const prompts = batch.map((s) => buildPromptTokens(8, 0, s.nonce, [[7, 8, 9, 10]]).join(","));
     expect(new Set(prompts).size).toBe(4);
   });
 

--- a/worker/src/loadDriver.ts
+++ b/worker/src/loadDriver.ts
@@ -18,9 +18,6 @@ import type { CaveatFlag } from "../../shared/types.js";
 // exactly at the context-size edge. Same constant serverBench.ts uses.
 export const CONTEXT_MARGIN = 256;
 
-export const FILLER_TOKEN_RANGE_START = 100;
-export const FILLER_TOKEN_RANGE_SIZE = 500;
-
 // Slot accounting (N1/N5, stated identically in both): per-slot demand is the
 // full prompt plus the generation budget, and -c covers every slot. At
 // parallel 1 this equals the existing sizing.
@@ -104,20 +101,6 @@ export function buildServerArgs(input: ServerArgsInput): string[] {
   // the logs then show a shift happened anyway.
   if (input.supportsNoContextShift) args.push("--no-context-shift");
   return args;
-}
-
-// A synthetic prompt of exactly n tokens, sent pre-tokenized so the count is
-// exact rather than tokenizer-dependent. `nonce` shifts the sequence: N5's
-// concurrent streams each carry a DISTINCT suffix so the prefix cache cannot
-// dedupe them (otherwise later streams read artificially fast against a warm
-// prefix), and N1's warm/discard request uses a nonce prompt distinct from
-// the measured one so it never seeds the measured prefix into the cache.
-export function buildPromptTokens(tokenCount: number, offset = 0, nonce = 0): number[] {
-  const tokens: number[] = [];
-  for (let i = 0; i < tokenCount; i++) {
-    tokens.push(FILLER_TOKEN_RANGE_START + offset + ((i + nonce * 7919) % FILLER_TOKEN_RANGE_SIZE));
-  }
-  return tokens;
 }
 
 // --- Streaming measurement --------------------------------------------------

--- a/worker/src/runtimeBench.test.ts
+++ b/worker/src/runtimeBench.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  completeWithRetries,
   executeCurvePoint,
   executeKneeLadder,
   probeSucceeded,
@@ -43,6 +44,14 @@ function fakeServer(opts: { evictOnRepeat?: number; coldPromptMs?: number } = {}
   return { completion, requests };
 }
 
+// Supplied explicitly so no test reaches for a real /tokenize -- fetchFillerBlocks
+// throws rather than degrading, which is the point of it.
+const BLOCKS = [
+  Array.from({ length: 31 }, (_, i) => 1000 + i),
+  Array.from({ length: 43 }, (_, i) => 2000 + i),
+  Array.from({ length: 37 }, (_, i) => 3000 + i),
+];
+
 describe("N1 curve-point execution", () => {
   it("runs the three request classes in order and never averages them together", async () => {
     const server = fakeServer();
@@ -53,6 +62,7 @@ describe("N1 curve-point execution", () => {
       port: 1,
       serverLog: "",
       supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
       completion: server.completion,
     });
     expect(server.requests).toHaveLength(6); // 1 warm/discard + 1 cold + 4 warm
@@ -79,6 +89,51 @@ describe("N1 curve-point execution", () => {
     expect(tg.repeat_samples).toHaveLength(4);
   });
 
+  // The filler prompt has to be built from ids that decode to valid UTF-8 in
+  // the model's OWN vocabulary, or llama.cpp's chat-output parser rejects the
+  // generation it provokes -- and it has to carry every register, or MoE
+  // prefill reads up to 58% fast (see fillerPrompt.ts).
+  it("builds every prompt out of the supplied filler blocks, carrying every register", async () => {
+    const server = fakeServer();
+    const all = new Set(BLOCKS.flat());
+    await executeCurvePoint({
+      effectiveCtx: 256,
+      nGen: 8,
+      repeats: 2,
+      port: 1,
+      serverLog: "",
+      supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
+      completion: server.completion,
+    });
+    expect(server.requests.length).toBeGreaterThan(0);
+    expect(server.requests.every((r) => r.promptTokens.every((t) => all.has(t)))).toBe(true);
+    const measured = server.requests[server.requests.length - 1].promptTokens;
+    expect(new Set(measured.map((t) => Math.floor(t / 1000))).size).toBe(BLOCKS.length);
+  });
+
+  it("asks the running server to tokenize the filler when no blocks are supplied", async () => {
+    const server = fakeServer();
+    const fetchMock = vi.fn(async (..._args: unknown[]) => Response.json({ tokens: [9000, 9001, 9002] }));
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      await executeCurvePoint({
+        effectiveCtx: 256,
+        nGen: 8,
+        repeats: 2,
+        port: 1,
+        serverLog: "",
+        supportsNoContextShift: true,
+        completion: server.completion,
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(fetchMock).toHaveBeenCalled();
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/tokenize"))).toBe(true);
+    expect(server.requests.every((r) => r.promptTokens.every((t) => t >= 9000))).toBe(true);
+  });
+
   it("stamps METHOD_VERSION 2 so ordinary runtime rows can never land in a curve", async () => {
     const server = fakeServer();
     const execution = await executeCurvePoint({
@@ -88,6 +143,7 @@ describe("N1 curve-point execution", () => {
       port: 1,
       serverLog: "",
       supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
       completion: server.completion,
     });
     expect(execution.results.every((r) => r.method_version === CURVE_METHOD_VERSION)).toBe(true);
@@ -102,6 +158,7 @@ describe("N1 curve-point execution", () => {
       port: 1,
       serverLog: "",
       supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
       completion: server.completion,
     });
     expect(execution.results.every((r) => (r.caveat_flags ?? []).includes("cache_evicted"))).toBe(true);
@@ -117,6 +174,7 @@ describe("N1 curve-point execution", () => {
       port: 1,
       serverLog: "",
       supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
       completion: server.completion,
     });
     expect(execution.results.every((r) => (r.caveat_flags ?? []).length === 0)).toBe(true);
@@ -132,6 +190,7 @@ describe("N1 curve-point execution", () => {
       port: 1,
       serverLog: "slot update_slots: slot context shift, n_keep = 0",
       supportsNoContextShift: false,
+      fillerBlocks: BLOCKS,
       completion: server.completion,
     });
     expect(execution.results.every((r) => (r.caveat_flags ?? []).includes("context_shift"))).toBe(true);
@@ -153,6 +212,7 @@ describe("N1 curve-point execution", () => {
       port: 1,
       serverLog: "",
       supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
       completion,
     });
     const pp = execution.results.find((r) => r.test_type === "pp")!;
@@ -184,6 +244,7 @@ describe("N5 knee ladder execution", () => {
       nGen: 128,
       repeats: 1,
       slots: [1, 2, 4],
+      fillerBlocks: BLOCKS,
       port: 1,
       completion,
     });
@@ -206,7 +267,7 @@ describe("N5 knee ladder execution", () => {
         slot: input.slot ?? 0,
       };
     };
-    await executeKneeLadder({ nPrompt: 64, nGen: 8, repeats: 1, slots: [4], port: 1, completion });
+    await executeKneeLadder({ nPrompt: 64, nGen: 8, repeats: 1, slots: [4], port: 1, fillerBlocks: BLOCKS, completion });
     expect(new Set(prompts).size).toBe(4);
   });
 });
@@ -355,15 +416,134 @@ describe("spawnRuntimeServer readiness failures", () => {
   }, 10_000);
 });
 
-// Live-reproduced against a real Qwen3.5/3.8 "thinking" GGUF on llama.cpp
-// b10793: llama-server accepts a raw /completion request (HTTP 200, stream
-// opens normally) and then emits an {"error":...} SSE frame instead of real
-// content -- its chat-format output validator rejecting the model's own
-// generated text. Confirmed independent of --reasoning-format,
+// The context tests used to have no recovery at all: one LlamaServerOutputError
+// propagated out and index.ts marked the whole probe ladder fatal, abandoning
+// every remaining placement over a single request. The MTP path had had a retry
+// ladder for months.
+describe("parser-failure recovery", () => {
+  const parserError = () =>
+    new LlamaServerOutputError("rejected", "The model produced output that does not match the expected Content-only format");
+
+  const sample = (): StreamSample => ({
+    ttftMs: 10,
+    e2eMs: 20,
+    tokensPredicted: 8,
+    promptN: 64,
+    promptMs: 5,
+    slot: 0,
+  });
+
+  function recorder(failures: number) {
+    const seen: { first: number; grammar?: string }[] = [];
+    let calls = 0;
+    const completion = async (input: StreamedRequestInput): Promise<StreamSample> => {
+      seen.push({ first: input.promptTokens[0], grammar: input.grammar });
+      if (calls++ < failures) throw parserError();
+      return sample();
+    };
+    return { completion, seen };
+  }
+
+  it("retries on a DIFFERENT prompt, because an identical greedy retry provably fails identically", async () => {
+    const { completion, seen } = recorder(1);
+    const out = await completeWithRetries({
+      completion, port: 1, tokenCount: 64, offset: 0, nonce: 0,
+      blocks: BLOCKS, nPredict: 8, cachePrompt: false,
+    });
+    expect(out.grammarConstrained).toBe(false);
+    expect(seen).toHaveLength(2);
+    expect(seen[1].first).not.toBe(seen[0].first);
+    expect(seen.every((r) => r.grammar === undefined)).toBe(true);
+  });
+
+  it("falls back to a grammar only after every unconstrained attempt is rejected, and says so", async () => {
+    const { completion, seen } = recorder(3);
+    const out = await completeWithRetries({
+      completion, port: 1, tokenCount: 64, offset: 0, nonce: 0,
+      blocks: BLOCKS, nPredict: 8, cachePrompt: false,
+    });
+    expect(out.grammarConstrained).toBe(true);
+    expect(seen).toHaveLength(4);
+    // Three unconstrained attempts, each on its own prompt, then the grammar.
+    expect(seen.slice(0, 3).every((r) => r.grammar === undefined)).toBe(true);
+    expect(new Set(seen.slice(0, 3).map((r) => r.first)).size).toBe(3);
+    expect(seen[3].grammar).toMatch(/^root ::=/);
+  });
+
+  it("stays fatal when even the grammar attempt is rejected -- no other placement will differ", async () => {
+    const completion = async (): Promise<StreamSample> => {
+      throw parserError();
+    };
+    await expect(
+      completeWithRetries({
+        completion, port: 1, tokenCount: 64, offset: 0, nonce: 0,
+        blocks: BLOCKS, nPredict: 8, cachePrompt: false,
+      })
+    ).rejects.toBeInstanceOf(LlamaServerOutputError);
+  });
+
+  it("does not burn retries on an error that another prompt cannot fix", async () => {
+    let calls = 0;
+    const completion = async (): Promise<StreamSample> => {
+      calls++;
+      throw new Error("llama-server /completion returned 503");
+    };
+    await expect(
+      completeWithRetries({
+        completion, port: 1, tokenCount: 64, offset: 0, nonce: 0,
+        blocks: BLOCKS, nPredict: 8, cachePrompt: false,
+      })
+    ).rejects.toThrow("503");
+    expect(calls).toBe(1);
+  });
+
+  it("flags a curve point whose reading only came back under a grammar", async () => {
+    let calls = 0;
+    const completion = async (input: StreamedRequestInput): Promise<StreamSample> => {
+      // Only the very first request needs the grammar; the flag must still
+      // reach the row, since that request is the cold TIMED prefill.
+      if (!input.grammar && calls++ < 3) throw parserError();
+      return { ...sample(), promptN: input.promptTokens.length };
+    };
+    const execution = await executeCurvePoint({
+      effectiveCtx: 256,
+      nGen: 8,
+      repeats: 2,
+      port: 1,
+      serverLog: "",
+      supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
+      completion,
+    });
+    expect(execution.results.length).toBeGreaterThan(0);
+    expect(execution.results.every((r) => (r.caveat_flags ?? []).includes("grammar_constrained"))).toBe(true);
+  });
+
+  it("leaves the flag off when nothing needed constraining", async () => {
+    const server = fakeServer();
+    const execution = await executeCurvePoint({
+      effectiveCtx: 256,
+      nGen: 8,
+      repeats: 2,
+      port: 1,
+      serverLog: "",
+      supportsNoContextShift: true,
+      fillerBlocks: BLOCKS,
+      completion: server.completion,
+    });
+    expect(execution.results.every((r) => !(r.caveat_flags ?? []).includes("grammar_constrained"))).toBe(true);
+  });
+});
+
+// Live-reproduced against a real Qwen3.8 GGUF on llama.cpp b10793:
+// llama-server accepts a raw /completion request (HTTP 200, stream opens
+// normally) and then emits an {"error":...} SSE frame instead of real content
+// -- its chat-output PEG parser hard-failing over one invalid UTF-8 byte in
+// the generated text. Confirmed independent of --reasoning-format,
 // --skip-chat-parsing, -rea off, --reasoning-budget and ignore_eos (see
-// ggml-org/llama.cpp#19869 and friends). Before this, streamedCompletion had
-// no way to see that frame as anything other than "the model generated zero
-// tokens" -- see the two tests below.
+// ggml-org/llama.cpp#25072, and fillerPrompt.ts for the mechanism). Before
+// this, streamedCompletion had no way to see that frame as anything other
+// than "the model generated zero tokens" -- see the two tests below.
 describe("streamedCompletion / llama-server SSE error frames", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -397,8 +577,8 @@ describe("streamedCompletion / llama-server SSE error frames", () => {
     );
     const call = streamedCompletion({ port: 1, promptTokens: [100, 101, 102], nPredict: 8, cachePrompt: false });
     await expect(call).rejects.toBeInstanceOf(LlamaServerOutputError);
-    await expect(call).rejects.toThrow(/testing can't run correctly for it on this build/);
-    await expect(call).rejects.toThrow(/ggml-org\/llama\.cpp#19869/);
+    await expect(call).rejects.toThrow(/one invalid UTF-8 byte/);
+    await expect(call).rejects.toThrow(/ggml-org\/llama\.cpp#25072/);
   });
 
   it("falls back to a plainer message for an error signature it hasn't seen before, without claiming this specific diagnosis", async () => {

--- a/worker/src/runtimeBench.ts
+++ b/worker/src/runtimeBench.ts
@@ -9,7 +9,7 @@
 
 import { spawn, type ChildProcess } from "node:child_process";
 import type { IngestResultInput } from "../../shared/types.js";
-import { CURVE_METHOD_VERSION, METHOD_VERSION } from "../../shared/types.js";
+import { CURVE_METHOD_VERSION, SERVER_METHOD_VERSION, type CaveatFlag } from "../../shared/types.js";
 import type { SweepItem } from "../../shared/sweep.js";
 import {
   collapseTensorLoadSpam,
@@ -18,8 +18,8 @@ import {
   type BenchLogger,
   type BenchResult,
 } from "./bench.js";
+import { buildPromptTokens, fetchFillerBlocks, type FillerBlocks } from "./fillerPrompt.js";
 import {
-  buildPromptTokens,
   buildServerArgs,
   contextSizeForSlots,
   curveCaveatFlags,
@@ -178,6 +178,13 @@ export interface StreamedRequestInput {
   cachePrompt: boolean;
   slot?: number;
   signal?: AbortSignal;
+  /**
+   * GBNF constraining what may be sampled. Only ever set by the last-resort
+   * retry below, and only for a model that cannot otherwise produce a parseable
+   * response at all -- constrained sampling has its own cost, so any row
+   * measured this way is flagged grammar_constrained.
+   */
+  grammar?: string;
 }
 
 // Thrown when llama-server accepts a /completion request (HTTP 200, stream
@@ -200,21 +207,104 @@ export class LlamaServerOutputError extends Error {
   }
 }
 
-// The one signature we've actually root-caused (see ggml-org/llama.cpp
-// #19869 and friends): llama-server's structured-output ("Content-only")
-// parser rejecting a "thinking"-template model's raw output, reproduced live
-// against build b10793 -- confirmed independent of --reasoning-format,
-// --skip-chat-parsing, -rea off and --reasoning-budget, all of which still
-// hit the identical failure. Anything else gets a plainer fallback rather
-// than falsely claiming this specific diagnosis for an error we haven't seen.
+// The one signature we've actually root-caused: llama.cpp's chat-output PEG
+// parser hard-failing the whole response over a single invalid-UTF-8 byte in
+// the generated text (ggml-org/llama.cpp#25072 -- see fillerPrompt.ts for the
+// mechanism and why no server flag or request field makes it tolerant).
+//
+// The usual cause was our OWN filler prompt, which used to be built from raw
+// single-byte token ids and reliably provoked byte-fragment output; that is
+// fixed at the source in fillerPrompt.ts. This stays as the guard for the
+// residual case (a model that emits an invalid byte anyway -- observed on MTP
+// builds), and anything that is not this signature gets a plainer fallback
+// rather than falsely claiming this diagnosis.
 function describeLlamaServerError(rawMessage: string): string {
-  if (rawMessage.includes("Content-only")) {
+  if (/does not match the expected .*format/i.test(rawMessage)) {
     return (
-      "This model's output was rejected by llama-server as invalid -- testing can't run correctly for it on this build. " +
-      "This is a known llama.cpp limitation with 'thinking'/reasoning-style models (see ggml-org/llama.cpp#19869), not a hardware or configuration problem."
+      "llama-server rejected this model's generated output as invalid: llama.cpp's chat-output parser fails a whole " +
+      "response over one invalid UTF-8 byte, and no server flag disables that check (ggml-org/llama.cpp#25072). " +
+      "This is an upstream llama.cpp limitation, not a hardware or configuration problem."
     );
   }
   return `llama-server reported an error during generation: ${rawMessage}`;
+}
+
+// --- Recovering from the parser failure -------------------------------------
+//
+// Three attempts, each with a different prompt, then one grammar-constrained
+// attempt as a last resort. Mirrors the MTP path's ladder (serverBench.ts) --
+// which the context tests never had: before this, a single
+// LlamaServerOutputError propagated straight out and index.ts marked the whole
+// probe ladder fatal, so one unlucky request abandoned every remaining
+// placement.
+//
+// Retrying with a DIFFERENT prompt is the whole point: sampling is greedy
+// (temperature 0), so a byte-for-byte identical retry provably fails
+// identically -- confirmed live on the MTP path, 3 attempts out of 3.
+const MAX_COMPLETION_ATTEMPTS = 3;
+// Rotates the filler on each retry. Same constant, and the same reasoning, as
+// serverBench.ts's RETRY_PROMPT_SHIFT.
+const RETRY_PROMPT_SHIFT = 137;
+
+// The last resort. Confirmed live against b10793: the exact request that fails
+// with "does not match the expected Content-only format" succeeds under a
+// grammar, because the sampler can no longer reach a token whose bytes are an
+// invalid UTF-8 fragment. Deliberately plain ASCII -- the point is to make an
+// invalid byte unreachable, not to shape the text.
+const FALLBACK_GRAMMAR = 'root ::= [a-zA-Z0-9 ,.;:!?\\n]+';
+
+export interface ResilientCompletionInput {
+  completion: CompletionFn;
+  port: number;
+  tokenCount: number;
+  offset: number;
+  nonce: number;
+  blocks: FillerBlocks;
+  nPredict: number;
+  cachePrompt: boolean;
+  slot?: number;
+  log?: BenchLogger;
+}
+
+export interface ResilientCompletion {
+  sample: StreamSample;
+  /** True when only the grammar-constrained attempt produced a reading. */
+  grammarConstrained: boolean;
+}
+
+export async function completeWithRetries(input: ResilientCompletionInput): Promise<ResilientCompletion> {
+  const attemptAt = (offset: number, grammar?: string) =>
+    input.completion({
+      port: input.port,
+      promptTokens: buildPromptTokens(input.tokenCount, offset, input.nonce, input.blocks),
+      nPredict: input.nPredict,
+      cachePrompt: input.cachePrompt,
+      slot: input.slot,
+      ...(grammar ? { grammar } : {}),
+    });
+
+  for (let attempt = 0; attempt < MAX_COMPLETION_ATTEMPTS; attempt++) {
+    const offset = input.offset + attempt * RETRY_PROMPT_SHIFT;
+    try {
+      return { sample: await attemptAt(offset), grammarConstrained: false };
+    } catch (err) {
+      // Only the parser failure is worth another prompt; anything else (a dead
+      // server, a timeout) fails fast rather than being retried three times.
+      if (!(err instanceof LlamaServerOutputError)) throw err;
+      input.log?.warn(
+        `llama-server rejected its own output at prompt offset ${offset} ` +
+          `(attempt ${attempt + 1}/${MAX_COMPLETION_ATTEMPTS}): ${err.rawMessage}`
+      );
+    }
+  }
+
+  input.log?.warn(
+    "every unconstrained attempt was rejected; retrying under a grammar so this configuration " +
+      "still yields a reading -- the row will be flagged grammar_constrained"
+  );
+  // A failure here is genuine and stays fatal: nothing about this model can
+  // generate through this endpoint, and no other placement will differ.
+  return { sample: await attemptAt(input.offset, FALLBACK_GRAMMAR), grammarConstrained: true };
 }
 
 // TTFT is the arrival of the FIRST streamed chunk, measured here rather than
@@ -238,6 +328,7 @@ export async function streamedCompletion(input: StreamedRequestInput): Promise<S
       cache_prompt: input.cachePrompt,
       ignore_eos: true,
       temperature: 0,
+      ...(input.grammar ? { grammar: input.grammar } : {}),
     }),
   });
   if (!res.ok || !res.body) {
@@ -311,6 +402,12 @@ export interface CurvePointExecutionInput {
   serverLog: string;
   supportsNoContextShift: boolean;
   completion?: CompletionFn;
+  /**
+   * Tokenized filler blocks (see fillerPrompt.ts). Omit and they are fetched
+   * from the running server, which is the only way to get ids valid in this
+   * model's vocabulary; supplied explicitly only by tests.
+   */
+  fillerBlocks?: FillerBlocks;
   log?: BenchLogger;
 }
 
@@ -328,6 +425,7 @@ export interface CurvePointExecution {
 //   * warm_repeat -> the tg row's rate, stddev and e2e mean.
 export async function executeCurvePoint(input: CurvePointExecutionInput): Promise<CurvePointExecution> {
   const completion = input.completion ?? streamedCompletion;
+  const fillerBlocks = input.fillerBlocks ?? (await fetchFillerBlocks(input.port));
   const plan = planCurvePoint({
     promptTokens: input.effectiveCtx,
     nGen: input.nGen,
@@ -335,14 +433,21 @@ export async function executeCurvePoint(input: CurvePointExecutionInput): Promis
   });
 
   const samples: (StreamSample & { requestClass: RequestClass })[] = [];
+  let grammarConstrained = false;
   for (const step of plan) {
-    const sample = await completion({
+    const outcome = await completeWithRetries({
+      completion,
       port: input.port,
-      promptTokens: buildPromptTokens(step.promptTokens, input.promptOffset ?? 0, step.nonce),
+      tokenCount: step.promptTokens,
+      offset: input.promptOffset ?? 0,
+      nonce: step.nonce,
+      blocks: fillerBlocks,
       nPredict: step.nPredict,
       cachePrompt: step.cachePrompt,
+      log: input.log,
     });
-    samples.push({ ...sample, requestClass: step.requestClass });
+    grammarConstrained ||= outcome.grammarConstrained;
+    samples.push({ ...outcome.sample, requestClass: step.requestClass });
   }
 
   const cold = samples.find((s) => s.requestClass === "cold_timed");
@@ -352,6 +457,7 @@ export async function executeCurvePoint(input: CurvePointExecutionInput): Promis
     serverLog: input.serverLog,
     supportsNoContextShift: input.supportsNoContextShift,
   });
+  if (grammarConstrained) caveats.push("grammar_constrained");
 
   const results: IngestResultInput[] = [];
   const shared = {
@@ -366,9 +472,11 @@ export async function executeCurvePoint(input: CurvePointExecutionInput): Promis
     mtp: "off",
     n_gpu_layers_draft: 0,
     n_cpu_moe: 0,
-    // Choreographed points stamp METHOD_VERSION 2 -- cold-timed prefill plus
+    // Choreographed points stamp their own vintage -- cold-timed prefill plus
     // warm-repeat statistics is a real semantics change under §0.1, and that
-    // stamp is what keeps ordinary runtime rows out of curves.
+    // stamp is what keeps ordinary runtime rows out of curves. Bumped again
+    // when the filler prompt became a mixed-register passage, which moved
+    // measured MoE prefill by 58%.
     method_version: CURVE_METHOD_VERSION,
     caveat_flags: caveats,
     prompt_offset: input.promptOffset ?? 0,
@@ -440,6 +548,8 @@ export interface KneeExecutionInput {
   port: number;
   promptOffset?: number;
   completion?: CompletionFn;
+  /** See CurvePointExecutionInput.fillerBlocks. */
+  fillerBlocks?: FillerBlocks;
   log?: BenchLogger;
   /** Called before each slot count so the caller can restart the server with the right --parallel. */
   beforeSlotCount?: (slots: number) => Promise<number>;
@@ -452,22 +562,32 @@ export async function executeKneeLadder(input: KneeExecutionInput): Promise<Inge
   const rows: IngestResultInput[] = [];
   for (const slots of input.slots) {
     const port = (await input.beforeSlotCount?.(slots)) ?? input.port;
+    // Re-fetched per slot count because beforeSlotCount restarts the server
+    // (same model, so the same blocks -- but this never assumes that).
+    const fillerBlocks = input.fillerBlocks ?? (await fetchFillerBlocks(port));
     const batchSamples: StreamSample[] = [];
+    let grammarConstrained = false;
     for (let repeat = 0; repeat < Math.max(1, input.repeats); repeat++) {
       const plan = planConcurrentBatch({ slots, promptTokens: input.nPrompt, nGen: input.nGen });
       // Simultaneous, not sequential -- that is the whole measurement.
       const batch = await Promise.all(
         plan.map((step) =>
-          completion({
+          completeWithRetries({
+            completion,
             port,
-            promptTokens: buildPromptTokens(step.promptTokens, input.promptOffset ?? 0, step.nonce + repeat * 1000),
+            tokenCount: step.promptTokens,
+            offset: input.promptOffset ?? 0,
+            nonce: step.nonce + repeat * 1000,
+            blocks: fillerBlocks,
             nPredict: step.nPredict,
             cachePrompt: false,
             slot: step.slot,
+            log: input.log,
           })
         )
       );
-      batchSamples.push(...batch);
+      if (batch.some((b) => b.grammarConstrained)) grammarConstrained = true;
+      batchSamples.push(...batch.map((b) => b.sample));
     }
     const summary = summarizeStreams(batchSamples);
     const shared = {
@@ -482,7 +602,8 @@ export async function executeKneeLadder(input: KneeExecutionInput): Promise<Inge
       mtp: "off",
       n_gpu_layers_draft: 0,
       n_cpu_moe: 0,
-      method_version: METHOD_VERSION,
+      method_version: SERVER_METHOD_VERSION,
+      caveat_flags: grammarConstrained ? (["grammar_constrained"] as CaveatFlag[]) : undefined,
       concurrency: slots,
       ttft_ms_p50: summary.ttftP50Ms,
       ttft_ms_p95: summary.ttftP95Ms,

--- a/worker/src/serverBench.ts
+++ b/worker/src/serverBench.ts
@@ -16,6 +16,8 @@ import {
   type OffloadResult,
 } from "./bench.js";
 import { estimateResidentGpuLayersFromBufferSizes } from "../../shared/vramEstimate.js";
+import { buildPromptTokens, fetchFillerBlocks, type FillerBlocks } from "./fillerPrompt.js";
+import { SERVER_METHOD_VERSION } from "../../shared/types.js";
 
 // Drives llama-server over HTTP to benchmark MTP (multi-token-prediction)
 // speculative decoding -- llama-bench itself has no --spec-type/--model-draft
@@ -63,20 +65,11 @@ const STOP_GRACE_MS = 5000;
 // (special tokens, its internal bookkeeping) never rejects a request that's
 // exactly at the context-size edge.
 const CONTEXT_MARGIN = 256;
-// Cycled through (not repeated verbatim) to build a synthetic prompt of
-// exactly n_prompt tokens -- mirrors llama-bench's own "-p is a token count,
-// not real text, content is irrelevant to what's being measured" semantics
-// (see llm-benchmark-plan-v2.md), sent as a pre-tokenized array rather than
-// a text string so the token count is exact rather than tokenizer-dependent.
-// Deliberately NOT a single token repeated hundreds of times in a row --
-// confirmed live against a real MTP build that an all-identical-token
-// prompt reliably drove speculative decoding into producing invalid UTF-8
-// output bytes (llama-server's own response parser then hard-fails with a
-// "Content-only format" 500 before any timings come back at all). Cycling
-// through a range keeps the same "count is all that matters" property
-// without being a maximally repetitive, out-of-distribution edge case.
-const FILLER_TOKEN_RANGE_START = 100;
-const FILLER_TOKEN_RANGE_SIZE = 500;
+// The synthetic filler prompt itself lives in fillerPrompt.ts -- including
+// the long-form explanation of the invalid-UTF-8 parser failure below, and
+// why the prompt is built from server-tokenized real text rather than a raw
+// range of token ids (the old scheme's ids landed in the vocabulary's raw
+// single-byte region and provoked exactly this failure).
 
 // A single /completion call, retried this many times total before the repeat
 // is allowed to fail the whole item -- see isRetryableServerParseFailure.
@@ -92,8 +85,10 @@ const MAX_COMPLETION_ATTEMPTS = 3;
 // unlike the INCOMPLETE case, this path does not check the parser's lenient
 // flag at all. So there is no request field or server flag that makes this
 // tolerant: ONE invalid byte anywhere in a generation fails the entire
-// response, even under the simplest possible chat format. MTP/speculative
-// decoding occasionally emits such a byte (observed live: a short run of
+// response, even under the simplest possible chat format. The dominant source
+// of such a byte was our own filler prompt (raw single-byte token ids -- now
+// fixed at the source, see fillerPrompt.ts); what remains is MTP/speculative
+// decoding occasionally emitting one (observed live: a short run of
 // invalid-UTF-8 characters, followed by otherwise-clean, coherent generated
 // text -- consistent with the accept/reject boundary landing mid-way through
 // what should have been an atomic multi-byte token sequence). Bounded retry
@@ -106,9 +101,9 @@ const MAX_COMPLETION_ATTEMPTS = 3;
 // pipeline is random). Deliberately narrow (matches this exact message
 // shape) so a genuinely different server error still fails fast.
 const RETRYABLE_SERVER_PARSE_FAILURE = /does not match the expected .*format/i;
-// Added to FILLER_TOKEN_RANGE_START on each retry attempt (see runCompletion
-// below) so a retry sends a genuinely different token sequence rather than
-// replaying the exact request that just failed -- see the comment above.
+// Rotates the filler prompt on each retry attempt (see runCompletion below)
+// so a retry sends a genuinely different token sequence rather than replaying
+// the exact request that just failed -- see the comment above.
 const RETRY_PROMPT_SHIFT = 137;
 
 function isRetryableServerParseFailure(err: unknown): boolean {
@@ -401,26 +396,20 @@ function evaluateRate(
   return { value, suspect: value <= 0 || value > ceiling };
 }
 
-function syntheticPrompt(n: number, offset = 0): number[] {
-  return Array.from(
-    { length: Math.max(0, n) },
-    (_, i) => FILLER_TOKEN_RANGE_START + ((i + offset) % FILLER_TOKEN_RANGE_SIZE)
-  );
-}
-
 async function runCompletion(
   port: number,
   nPrompt: number,
   nGen: number,
   timeoutMs: number,
-  promptOffset = 0
+  promptOffset = 0,
+  fillerBlocks: FillerBlocks = []
 ): Promise<CompletionOutcome> {
   const startedAt = performance.now();
   const res = await fetch(`http://127.0.0.1:${port}/completion`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
-      prompt: syntheticPrompt(nPrompt, promptOffset),
+      prompt: buildPromptTokens(nPrompt, promptOffset, 0, fillerBlocks),
       n_predict: nGen,
       // Without this, llama-server stops as soon as it samples an EOS/stop
       // token instead of decoding all nGen tokens -- confirmed live on an
@@ -715,6 +704,11 @@ export async function runServerBench(input: ServerBenchRunInput): Promise<BenchR
     // further once the sampler's telemetry is in.
     log?.info(`${label}: offload: ${formatOffloadForLog(offload, modelBufferSizes)} (claimed)`);
 
+    // Fetched here (not earlier) because it needs a server that has finished
+    // loading the model -- /tokenize answers in that model's own vocabulary.
+    // Throws rather than degrading: see fetchFillerBlocks.
+    const fillerBlocks = await fetchFillerBlocks(input.port);
+
     const offsetStorePath = input.offsetStorePath ?? DEFAULT_OFFSET_STORE_PATH;
     const offsetKey = offsetStoreKey(input.modelPath, input.mtpModelPath);
     // Updated in place whenever a non-preferred offset succeeds, so later
@@ -772,7 +766,7 @@ export async function runServerBench(input: ServerBenchRunInput): Promise<BenchR
       for (let attempt = 1; ; attempt++) {
         const promptOffset = candidates[attempt - 1];
         try {
-          outcome = await runCompletion(input.port, item.n_prompt, item.n_gen, timeoutMs, promptOffset);
+          outcome = await runCompletion(input.port, item.n_prompt, item.n_gen, timeoutMs, promptOffset, fillerBlocks);
           if (promptOffset !== preferredOffset) {
             preferredOffset = promptOffset;
             saveWorkingOffset(offsetStorePath, offsetKey, preferredOffset, log);
@@ -889,6 +883,10 @@ export async function runServerBench(input: ServerBenchRunInput): Promise<BenchR
     const specDecode = await checkSpecDecodeMetrics(input.port, label, input.repeats, log);
 
     const commonFields = {
+      // Measured through llama-server, so it carries the server vintage rather
+      // than the shared one -- the mixed-register filler prompt changed what
+      // this path measures, and llama-bench rows must not be invalidated with it.
+      method_version: SERVER_METHOD_VERSION,
       n_prompt: item.n_prompt,
       n_gen: item.n_gen,
       n_threads: item.threads,


### PR DESCRIPTION
<!--
Contribution mechanics (scope, style, commit messages) are in CONTRIBUTING.md.
Keep this short — a couple of sentences is usually enough.
-->

## What this changes

## Why

## How it was verified

<!--
Which of these actually ran, and what they said. "npm test passes" is fine if
that's genuinely the whole story; say so explicitly if a change couldn't be
tested against real hardware.
-->

- [x] `npm test`
- [x] `npm run typecheck`
- [x] Exercised against a real worker / GPU (say which, and what the numbers looked like)
- [x] Checked in the browser (which pages)

## Notes for review

<!--
Anything worth flagging: a schema migration, a change to the worker protocol
(older workers stay in the field until they're restarted), a change to what
data is stored or shared, or a deliberate trade-off you'd like challenged.
-->
